### PR TITLE
CC-23050: Replace docker maven build with docker build. Tag with latest if branch on main.

### DIFF
--- a/.github/workflows/shared-branch-push-java.yml
+++ b/.github/workflows/shared-branch-push-java.yml
@@ -6,6 +6,9 @@ on:
       appName:
         type: string
         required: true
+      githubRefName:
+        type: string
+        required: false
 
 env:
   jiraServer: cartoncloud.atlassian.net
@@ -26,6 +29,7 @@ jobs:
           mavenS3SecretAccessKey: ${{ secrets.TEMP_MAVEN_S3_SECRET_ACCESS_KEY }}
           sonarUrl: ${{ secrets.SONAR_HOST_URL }}
           sonarToken: ${{ secrets.SONAR_TOKEN }}
+          githubRefName: ${{ inputs.githubRefName }}
 
   auto-update-list:
     name: Environment Updates

--- a/build-java/action.yml
+++ b/build-java/action.yml
@@ -18,6 +18,9 @@ inputs:
   versionTag:
     description: 'Version tag to apply to docker image'
     required: false
+  githubRefName:
+    description: 'Github ref name'
+    required: false
   mavenS3AccessKeyId:
     description: 'Maven S3 Access Key Id to upload artefact'
   mavenS3SecretAccessKey:
@@ -70,13 +73,16 @@ runs:
       id: login-ecr
       uses: aws-actions/amazon-ecr-login@v1
 
-    - name: Build tag docker image
-      env:
-        AWS_ACCESS_KEY_ID: ${{ inputs.mavenS3AccessKeyId }}
-        AWS_SECRET_ACCESS_KEY: ${{ inputs.mavenS3SecretAccessKey }}
+    - name: Build and tag docker image
       shell: bash
       run: |
-        mvn initialize dockerfile:build
+        docker build -t $REGISTRY/$REPOSITORY:$IMAGE_TAG .
+
+    - name: Tag docker image with latest for pushes on main branch
+      shell: bash
+      if: $ {{ inputs.githubRefName == 'main' }}
+      run: |
+        docker tag $REGISTRY/$REPOSITORY:$IMAGE_TAG $REGISTRY/$REPOSITORY:latest
 
     - name: Tag docker image
       shell: bash

--- a/build-java/action.yml
+++ b/build-java/action.yml
@@ -84,15 +84,6 @@ runs:
       run: |
         docker tag $REGISTRY/$REPOSITORY:$IMAGE_TAG $REGISTRY/$REPOSITORY:latest
 
-    - name: Tag docker image
-      shell: bash
-      env:
-        REGISTRY: 026388519853.dkr.ecr.us-west-2.amazonaws.com
-        REPOSITORY: ${{ inputs.appName }}
-        IMAGE_TAG: ${{ inputs.dockerTag }}
-      run: |
-        docker tag $REGISTRY/$REPOSITORY:latest $REGISTRY/$REPOSITORY:$IMAGE_TAG    
-
     - name: Tag image with version tag if present
       if: inputs.versionTag != ''
       shell: bash


### PR DESCRIPTION
Jake upgraded ECS in production to match test regions yesterday so docker images built with docker should work in production now.