### PR TITLE
CC-26563: move from node 12 to node 16 for aws-credentials

### DIFF
--- a/build-java/action.yml
+++ b/build-java/action.yml
@@ -84,7 +84,7 @@ runs:
       run:  mvn sonar:sonar -Dsonar.host.url=${{ inputs.sonarUrl }} -Dsonar.login=${{ inputs.sonarToken }}
 
     - name: Configure AWS Credentials
-      uses: aws-actions/configure-aws-credentials@master
+      uses: aws-actions/configure-aws-credentials@v1-node16
       with:
         role-to-assume: arn:aws:iam::026388519853:role/GithubToAwsOpenIdConnect
         aws-region: ${{ inputs.awsRegion }}

--- a/deploy-java/action.yml
+++ b/deploy-java/action.yml
@@ -84,7 +84,7 @@ runs:
         jiraPassword: ${{ inputs.jiraPassword }}
 
     - name: Configure AWS Credentials
-      uses: aws-actions/configure-aws-credentials@master
+      uses: aws-actions/configure-aws-credentials@v1-node16
       with:
         role-to-assume: arn:aws:iam::026388519853:role/GithubToAwsOpenIdConnect
         aws-region: ${{ inputs.awsRegion }}


### PR DESCRIPTION
see [Update action to use node 16 · Issue #489 · aws-actions/configure-aws-credentials](https://github.com/aws-actions/configure-aws-credentials/issues/489#issuecomment-1278145876)