### PR TITLE
Cut down build times by using restore keys to select existing cache if no exact match.

### DIFF
--- a/build-java/action.yml
+++ b/build-java/action.yml
@@ -58,7 +58,14 @@ runs:
       with:
         java-version: '11'
         distribution: 'temurin'
-        cache: 'maven'
+
+    - name: Cache local Maven repository
+      uses: actions/cache@v2
+      with:
+        path: ~/.m2/repository
+        key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+        restore-keys: |
+          ${{ runner.os }}-maven-
 
     - name: Update pom version
       env:

--- a/build-library-java/action.yml
+++ b/build-library-java/action.yml
@@ -21,7 +21,14 @@ runs:
       with:
         java-version: '11'
         distribution: 'temurin'
-        cache: 'maven'
+
+    - name: Cache local Maven repository
+      uses: actions/cache@v2
+      with:
+        path: ~/.m2/repository
+        key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+        restore-keys: |
+          ${{ runner.os }}-maven-        
 
     - name: Update pom version
       env:


### PR DESCRIPTION
Custom cache started working after pulled into `main`
![image](https://user-images.githubusercontent.com/3202664/219529391-64443b73-fdda-440a-9f72-94fba60d34f6.png)
