### PR TITLE
Add Elasticsearch for indexer service builds.

### DIFF
--- a/.github/workflows/shared-branch-push-java.yml
+++ b/.github/workflows/shared-branch-push-java.yml
@@ -47,7 +47,7 @@ jobs:
           --health-timeout 5s
           --health-retries 5
       elasticsearch:
-        image: docker.elastic.co/elasticsearch/elasticsearch:7.17.8
+        image: docker.elastic.co/elasticsearch/elasticsearch:6.8.23
         env:
           discovery.type: single-node
         options: >-

--- a/.github/workflows/shared-branch-push-java.yml
+++ b/.github/workflows/shared-branch-push-java.yml
@@ -46,6 +46,18 @@ jobs:
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5
+      elasticsearch:
+        image: docker.elastic.co/elasticsearch/elasticsearch:7.17.8
+        env:
+          discovery.type: single-node
+        options: >-
+          --health-cmd "curl http://localhost:9200/_cluster/health"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 10
+        ports:
+          # Maps port 9200 on service container to the host
+          - 9200:9200
 
     steps:
       - name: Add hosts to /etc/hosts


### PR DESCRIPTION
Tested with https://github.com/cartoncloud/service-indexer/actions/runs/4260120668/jobs/7412973379