### PR TITLE
PLT-204: org variable URL and node 16 default

### DIFF
--- a/.github/workflows/shared-branch-push-java.yml
+++ b/.github/workflows/shared-branch-push-java.yml
@@ -69,7 +69,7 @@ jobs:
           appName: ${{ inputs.appName }}
           mavenS3AccessKeyId: ${{ secrets.TEMP_MAVEN_S3_ACCESS_KEY_ID }}
           mavenS3SecretAccessKey: ${{ secrets.TEMP_MAVEN_S3_SECRET_ACCESS_KEY }}
-          sonarUrl: ${{ secrets.SONAR_HOST_URL }}
+          sonarUrl: ${{ vars.SONAR_HOST_URL }}
           sonarToken: ${{ secrets.SONAR_TOKEN }}
           jasperBuild: ${{ inputs.jasperBuild }}
           token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}

--- a/.github/workflows/shared-release-pull-request-java.yml
+++ b/.github/workflows/shared-release-pull-request-java.yml
@@ -182,7 +182,7 @@ jobs:
           dockerTag: ${{ github.event.pull_request.head.sha  }}
           mavenS3AccessKeyId: ${{ secrets.TEMP_MAVEN_S3_ACCESS_KEY_ID }}
           mavenS3SecretAccessKey: ${{ secrets.TEMP_MAVEN_S3_SECRET_ACCESS_KEY }}
-          sonarUrl: ${{ secrets.SONAR_HOST_URL }}
+          sonarUrl: ${{ vars.SONAR_HOST_URL }}
           sonarToken: ${{ secrets.SONAR_TOKEN }}
           jasperBuild: ${{ inputs.jasperBuild }}
           token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}

--- a/build-java/action.yml
+++ b/build-java/action.yml
@@ -106,7 +106,7 @@ runs:
       run: mvn sonar:sonar -Dsonar.host.url=${{ inputs.sonarUrl }} -Dsonar.login=${{ inputs.sonarToken }}
 
     - name: Configure AWS Credentials
-      uses: aws-actions/configure-aws-credentials@v1-node16
+      uses: aws-actions/configure-aws-credentials@v2
       with:
         role-to-assume: arn:aws:iam::026388519853:role/GithubToAwsOpenIdConnect
         aws-region: ${{ inputs.awsRegion }}

--- a/deploy-java/action.yml
+++ b/deploy-java/action.yml
@@ -95,7 +95,7 @@ runs:
         jiraPassword: ${{ inputs.jiraPassword }}
 
     - name: Configure AWS Credentials
-      uses: aws-actions/configure-aws-credentials@v1-node16
+      uses: aws-actions/configure-aws-credentials@v2
       with:
         role-to-assume: arn:aws:iam::026388519853:role/GithubToAwsOpenIdConnect
         aws-region: ${{ inputs.awsRegion }}


### PR DESCRIPTION
variable SONAR_HOST_URL https://sonar.dev.service.cartoncloud.com.au
secret unchanged - to be removed

configure-aws-credentials v2 now uses node 16 by default so no longer need special version