### PR TITLE
PLT-348 - Limiting environment sync to string parameters only

### DIFF
--- a/aws-environment-param-sync/src/index.js
+++ b/aws-environment-param-sync/src/index.js
@@ -15,6 +15,11 @@ const getParameter = async ({
         Path: path,
         Recursive: true,
         WithDecryption: false,
+        ParameterFilters: [{
+            Key: 'Type',
+            Option: 'Equals',
+            Values: ['String'],
+        }],
         NextToken: nextToken,
       })
       .promise();


### PR DESCRIPTION
It was pulling in SecureString params, eventually we want to shift the SecureString to sync to GitHub secrets but not needed yet.
Tested and working:
https://github.com/cartoncloud/service-configuration/actions/runs/6334121476