### PR TITLE
Changed github-download-multi-run-artifacts to work with run-names

### DIFF
--- a/github-download-multi-run-artifacts/src/index.ts
+++ b/github-download-multi-run-artifacts/src/index.ts
@@ -25,6 +25,19 @@ async function run() {
     const repo = inputRepo || github.context.repo.repo
 
     const octokit = github.getOctokit(token);
+    const workflows = await octokit.request('GET /repos/{owner}/{repo}/actions/workflows', {
+      owner,
+      repo,
+      headers: {
+        'X-GitHub-Api-Version': '2022-11-28'
+      }
+    })
+    const workflowMatchigTheName = workflows.data.workflows.filter(workflow=>workflow.name===workflowName)
+    if(!workflowMatchigTheName.length){
+      throw new Error('No workflow found for repository');
+    }
+    const workflowId = workflowMatchigTheName[0].id;
+
     const response = await octokit.request('GET /repos/{owner}/{repo}/actions/runs', {
         owner,
         repo,
@@ -33,7 +46,7 @@ async function run() {
         }
       })
     const filteredRunIdsList = response.data.workflow_runs
-    .filter(workflow=>workflow.name===workflowName)
+    .filter(workflow=>workflow.workflow_id===workflowId)
     .sort((a,b)=>{return b.run_number - a.run_number})
     .slice(0,workflowLimit)
     .map(workflow=>workflow.id);


### PR DESCRIPTION
Recent change to webapp-e2e test naming has broken the allure report upload, this makes "github-download-multi-run-artifacts" action compatible with the changes by filtering the workflow runs by the "workflow_id" instead of "name"