### PR TITLE
PLT-400-fix Moved newrelic inputs to Deploy to Production

### DIFF
--- a/.github/workflows/shared-release-pull-request-java.yml
+++ b/.github/workflows/shared-release-pull-request-java.yml
@@ -247,8 +247,6 @@ jobs:
           jiraServer: ${{ vars.JIRA_SERVER }}
           jiraUsername: ${{ secrets.JIRA_USERNAME }}
           jiraPassword: ${{ secrets.JIRA_PASSWORD }}
-          newrelicAPIKey: ${{ secrets.NEW_RELIC_API_KEY }}
-          newrelicEntityGUID: ${{ vars.NEW_RELIC_DEPLOYMENT_ENTITY_GUID }}
           gitHubPAT: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
           roleToAssumeForEcr: ${{ vars.AWS_ROLE_TO_ASSUME_FOR_ECR }}
           roleToAssumeForCluster: ${{ vars.AWS_ROLE_TO_ASSUME }}
@@ -417,6 +415,8 @@ jobs:
           jiraServer: ${{ vars.JIRA_SERVER }}
           jiraUsername: ${{ secrets.JIRA_USERNAME }}
           jiraPassword: ${{ secrets.JIRA_PASSWORD }}
+          newrelicAPIKey: ${{ secrets.NEW_RELIC_API_KEY }}
+          newrelicEntityGUID: ${{ vars.NEW_RELIC_DEPLOYMENT_ENTITY_GUID }}
           gitHubPAT: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
           roleToAssumeForEcr: ${{ vars.AWS_ROLE_TO_ASSUME_FOR_ECR }}
           roleToAssumeForCluster: ${{ vars.AWS_ROLE_TO_ASSUME }}


### PR DESCRIPTION
I have previously placed the newrelic inputs in Deploy workflow , but it should be in the Deploy to Production
It was causing the newrelic tag change to never trigger as it right now checks if the environment is set to"prod" as a requirement.
This PR fixes it.