### PR TITLE
Limiting dependabot PRs to 1

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,33 +3,7 @@ updates:
 
   - package-ecosystem: "github-actions"
     directory: "/"
-    schedule:
-      interval: "weekly"
-    assignees:
-      - "@cartoncloud/code-owners-platform"
-    reviewers:
-      - "@cartoncloud/code-owners-platform"
-
-  - package-ecosystem: "github-actions"
-    directory: "/deployment-status"
-    schedule:
-      interval: "weekly"
-    assignees:
-      - "@cartoncloud/code-owners-platform"
-    reviewers:
-      - "@cartoncloud/code-owners-platform"
-
-  - package-ecosystem: "github-actions"
-    directory: "/jira-deployment-status"
-    schedule:
-      interval: "weekly"
-    assignees:
-      - "@cartoncloud/code-owners-platform"
-    reviewers:
-      - "@cartoncloud/code-owners-platform"
-
-  - package-ecosystem: "github-actions"
-    directory: "/slack-deployment-status"
+    open-pull-requests-limit: 1 # Limit PR's to 1 to avoid overwhelming
     schedule:
       interval: "weekly"
     assignees:


### PR DESCRIPTION
- Not sure why we need the other dependabot config if the package-ecosystem is the same in the first config that checks everything in root directory.
- @garytimuss can you confirm if those are still needed? And if so why don't we have build-java, deploy-java ect.