### PR TITLE
Fix deployments when tags contain similar sequences eg. qa3 and qa31.

### DIFF
--- a/deploy-java/action.yml
+++ b/deploy-java/action.yml
@@ -124,7 +124,7 @@ runs:
       shell: bash
       run: |
         image_meta=$( aws ecr describe-images --region us-west-2 --repository-name ${{ inputs.appName }} --image-ids imageTag=${{ inputs.existingImageTag }} )
-        echo "existing=$(echo ${image_meta} | jq -c '.imageDetails[0] | select(.imageTags[] | contains("${{ inputs.environmentTag }}"))')" >> $GITHUB_OUTPUT
+        echo "existing=$(echo ${image_meta} | jq -c '.imageDetails[0] | select(.imageTags[] == "${{ inputs.environmentTag }}")')" >> $GITHUB_OUTPUT
 
     - name: Tag image with environment tag
       if: ${{ steps.deploy-check.outputs.existing == '' }}


### PR DESCRIPTION
Replace jq `contains` with a `==` to not return multiple images and break deployment for eg. `qa3` when tagged with `qa3` and `qa31`.