### PR TITLE
Update artifact action versions

### DIFF
--- a/.github/workflows/local-build.yml
+++ b/.github/workflows/local-build.yml
@@ -55,9 +55,9 @@ jobs:
           mkdir -p upload/${{ matrix.package }}/dist
           cp -a ${{ matrix.package }}/dist/. upload/${{ matrix.package }}/dist/
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
-          name: compiled-packages
+          name: compiled-packages-${{ matrix.package }}
           path: upload
           retention-days: 1
 
@@ -74,9 +74,9 @@ jobs:
       - name: Remove existing compiled actions
         run: find . -type d -name dist -prune -exec rm -rf {} \;
 
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
-          name: compiled-packages
+          merge-multiple: true
 
       - name: Changed files
         run: git diff --name-only


### PR DESCRIPTION
- Breaking changes for V3 -> V4, artifacts cannot be uploaded with the same name: https://github.com/actions/upload-artifact