### PR TITLE
Provide previous Jira label revision in output

### DIFF
--- a/jira-environment-revision-set/README.md
+++ b/jira-environment-revision-set/README.md
@@ -21,3 +21,8 @@ App/project name i.e. React
 
 ### revision (required)
 Git branch or tag
+
+## Outputs
+
+### existingRevision
+The revision that was previously set, if present

--- a/jira-environment-revision-set/dist/index.js
+++ b/jira-environment-revision-set/dist/index.js
@@ -6440,7 +6440,7 @@ var require_core = __commonJS({
 Support boolean input list: \`true | True | TRUE | false | False | FALSE\``);
     }
     exports.getBooleanInput = getBooleanInput;
-    function setOutput(name, value) {
+    function setOutput2(name, value) {
       const filePath = process.env["GITHUB_OUTPUT"] || "";
       if (filePath) {
         return file_command_1.issueFileCommand("OUTPUT", file_command_1.prepareKeyValueMessage(name, value));
@@ -6448,7 +6448,7 @@ Support boolean input list: \`true | True | TRUE | false | False | FALSE\``);
       process.stdout.write(os.EOL);
       command_1.issueCommand("set-output", { name }, utils_1.toCommandValue(value));
     }
-    exports.setOutput = setOutput;
+    exports.setOutput = setOutput2;
     function setCommandEcho(enabled) {
       command_1.issue("echo", enabled ? "on" : "off");
     }
@@ -7773,7 +7773,11 @@ async function run() {
       return;
     }
     const environment = matchingIssues.issues[0];
-    const labelsToRemove = environment.fields.labels.filter((it) => it.startsWith(labelPrefix));
+    const revisionLabels = environment.fields.labels.filter((it) => it.startsWith(labelPrefix));
+    const existingRevision = revisionLabels.length > 0 ? revisionLabels[0].replace(labelPrefix, "") : null;
+    if (existingRevision) {
+      core.setOutput("existingRevision", existingRevision);
+    }
     const updateResponse = await fetch(`https://${jiraServer}/rest/api/latest/issue/${environment.key}`, {
       method: "PUT",
       headers: {
@@ -7783,7 +7787,7 @@ async function run() {
       body: JSON.stringify({
         update: {
           labels: [
-            ...labelsToRemove.map((it) => ({ remove: it })),
+            ...revisionLabels.map((it) => ({ remove: it })),
             { add: labelToAdd }
           ]
         }

--- a/jira-environment-revision-set/dist/index.js
+++ b/jira-environment-revision-set/dist/index.js
@@ -7775,7 +7775,7 @@ async function run() {
     const environment = matchingIssues.issues[0];
     const revisionLabels = environment.fields.labels.filter((it) => it.startsWith(labelPrefix));
     const existingRevision = revisionLabels.length > 0 ? revisionLabels[0].replace(labelPrefix, "") : null;
-    if (existingRevision) {
+    if (existingRevision && existingRevision !== "Deploying\u2026") {
       core.setOutput("existingRevision", existingRevision);
     }
     const updateResponse = await fetch(`https://${jiraServer}/rest/api/latest/issue/${environment.key}`, {

--- a/jira-environment-revision-set/lib/index.js
+++ b/jira-environment-revision-set/lib/index.js
@@ -60,7 +60,11 @@ async function run() {
             return;
         }
         const environment = matchingIssues.issues[0];
-        const labelsToRemove = environment.fields.labels.filter((it) => it.startsWith(labelPrefix));
+        const revisionLabels = environment.fields.labels.filter((it) => it.startsWith(labelPrefix));
+        const existingRevision = revisionLabels.length > 0 ? revisionLabels[0].replace(labelPrefix, '') : null;
+        if (existingRevision) {
+            core.setOutput('existingRevision', existingRevision);
+        }
         const updateResponse = await (0, node_fetch_1.default)(`https://${jiraServer}/rest/api/latest/issue/${environment.key}`, {
             method: 'PUT',
             headers: {
@@ -70,7 +74,7 @@ async function run() {
             body: JSON.stringify({
                 update: {
                     labels: [
-                        ...labelsToRemove.map((it) => ({ remove: it })),
+                        ...revisionLabels.map((it) => ({ remove: it })),
                         { add: labelToAdd },
                     ],
                 },

--- a/jira-environment-revision-set/lib/index.js
+++ b/jira-environment-revision-set/lib/index.js
@@ -62,7 +62,7 @@ async function run() {
         const environment = matchingIssues.issues[0];
         const revisionLabels = environment.fields.labels.filter((it) => it.startsWith(labelPrefix));
         const existingRevision = revisionLabels.length > 0 ? revisionLabels[0].replace(labelPrefix, '') : null;
-        if (existingRevision) {
+        if (existingRevision && existingRevision !== 'Deploying…') {
             core.setOutput('existingRevision', existingRevision);
         }
         const updateResponse = await (0, node_fetch_1.default)(`https://${jiraServer}/rest/api/latest/issue/${environment.key}`, {

--- a/jira-environment-revision-set/src/index.ts
+++ b/jira-environment-revision-set/src/index.ts
@@ -42,7 +42,7 @@ async function run() {
     const revisionLabels: string[] = environment.fields.labels.filter((it: string) => it.startsWith(labelPrefix));
 
     const existingRevision = revisionLabels.length > 0 ? revisionLabels[0].replace(labelPrefix, '') : null;
-    if (existingRevision) {
+    if (existingRevision && existingRevision !== 'Deploying…') {
       core.setOutput('existingRevision', existingRevision);
     }
 

--- a/jira-environment-revision-set/src/index.ts
+++ b/jira-environment-revision-set/src/index.ts
@@ -39,7 +39,13 @@ async function run() {
     }
 
     const environment = matchingIssues.issues[0];
-    const labelsToRemove: string[] = environment.fields.labels.filter((it: string) => it.startsWith(labelPrefix));
+    const revisionLabels: string[] = environment.fields.labels.filter((it: string) => it.startsWith(labelPrefix));
+
+    const existingRevision = revisionLabels.length > 0 ? revisionLabels[0].replace(labelPrefix, '') : null;
+    if (existingRevision) {
+      core.setOutput('existingRevision', existingRevision);
+    }
+
     const updateResponse = await fetch(`https://${jiraServer}/rest/api/latest/issue/${environment.key}`, {
       method: 'PUT',
       headers: {
@@ -49,7 +55,7 @@ async function run() {
       body: JSON.stringify({
         update: {
           labels: [
-            ...labelsToRemove.map((it) => ({ remove: it })),
+            ...revisionLabels.map((it) => ({ remove: it })),
             { add: labelToAdd },
           ],
         },


### PR DESCRIPTION
Can then be used if a deploy is cancelled to reset the "Deploying..." revision back to what it was