### PR TITLE
CC-34118 option to pass javaVersion. Defaults to 11

### DIFF
--- a/build-java/action.yml
+++ b/build-java/action.yml
@@ -36,6 +36,10 @@ inputs:
     description: 'Personal access token owner username'
     default: cartoncloud-robot
     required: false
+  javaVersion:
+    description: "Version of JDK to use to build project"
+    default: 11
+    required: false
 
 runs:
   using: composite
@@ -59,10 +63,10 @@ runs:
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3
 
-    - name: Set up JDK 11
+    - name: Set up JDK
       uses: actions/setup-java@v4
       with:
-        java-version: '11'
+        java-version: '${{ inputs.javaVersion }}'
         distribution: 'temurin'
 
     - name: Cache local Maven repository


### PR DESCRIPTION
Need to build service-gateway with JDK 17.

Thinking that to use in service-gateway I add to below branch-push.yml. Please confirm correct. Thx

```
jobs:
  branch-push:
    name: Branch Push
    uses: cartoncloud/actions/.github/workflows/shared-branch-push-java.yml@v3
    with:
      appName: service-gateway
      githubRefName: ${{ github.ref_name }}
      javaVersion: 17  <--- ???
```