### PR TITLE
CC-34118 option to pass javaVersion. Defaults to 11

### DIFF
--- a/.github/workflows/shared-branch-push-java.yml
+++ b/.github/workflows/shared-branch-push-java.yml
@@ -12,6 +12,9 @@ on:
       jasperBuild:
         type: boolean
         required: false
+      javaVersion:
+        type: string
+        required: false
 
 jobs:
   build:


### PR DESCRIPTION
service-gateway build still failing. Hopefully this is it.