### PR TITLE
PLT-2053 - Add continueOnTimeout option to github-trigger-workflows-a…

### DIFF
--- a/github-trigger-workflows-and-wait/README.md
+++ b/github-trigger-workflows-and-wait/README.md
@@ -15,8 +15,25 @@ Name of the workflow
 ### waitTimeout
 Time in seconds to wait for triggered actions to complete before concluding timeout error
 
+Default: `1200` (20 minutes)
+
 ### checkInterval
-description: Time in seconds to wait between triggered workflow status updates
+Time in seconds to wait between triggered workflow status updates
+
+Default: `60`
+
+### continueOnTimeout
+If true, treat timeout as success instead of failure when workflows are still running at timeout.
+
+Default: `false`
+
+| Scenario | continueOnTimeout: false | continueOnTimeout: true |
+|----------|--------------------------|-------------------------|
+| Workflow succeeds within timeout | Success | Success |
+| Workflow fails within timeout | Failure | Failure |
+| Timeout reached, workflow still running | Failure | Success (continue) |
+
+> **Note:** "Success" means this action exits with code 0. When `continueOnTimeout: true` and timeout is reached, the triggered workflows may still be running in the background - their final status will not be tracked.
 
 ### repos (required)
 Repositories json object

--- a/github-trigger-workflows-and-wait/action.yml
+++ b/github-trigger-workflows-and-wait/action.yml
@@ -20,6 +20,10 @@ inputs:
     description: Time in seconds to wait between triggered workflow status updates
     type: numnber
     default: 60
+  continueOnTimeout:
+    description: 'If true, treat timeout as success instead of failure (workflow still running at timeout)'
+    type: boolean
+    default: false
   repos:
     description: 'Repositories json object'
     required: true

--- a/github-trigger-workflows-and-wait/dist/index.js
+++ b/github-trigger-workflows-and-wait/dist/index.js
@@ -18887,7 +18887,7 @@ var require_core = __commonJS({
       return inputs.map((input) => input.trim());
     }
     exports2.getMultilineInput = getMultilineInput;
-    function getBooleanInput(name, options) {
+    function getBooleanInput2(name, options) {
       const trueValue = ["true", "True", "TRUE"];
       const falseValue = ["false", "False", "FALSE"];
       const val = getInput2(name, options);
@@ -18898,7 +18898,7 @@ var require_core = __commonJS({
       throw new TypeError(`Input does not meet YAML 1.2 "Core Schema" specification: ${name}
 Support boolean input list: \`true | True | TRUE | false | False | FALSE\``);
     }
-    exports2.getBooleanInput = getBooleanInput;
+    exports2.getBooleanInput = getBooleanInput2;
     function setOutput(name, value) {
       const filePath = process.env["GITHUB_OUTPUT"] || "";
       if (filePath) {
@@ -23083,6 +23083,7 @@ async function run() {
     const workflowName = core.getInput("workflowName", { required: true });
     const waitTimeout = parseInt(core.getInput("waitTimeout", { required: false }));
     const checkInterval = parseInt(core.getInput("checkInterval", { required: false }));
+    const continueOnTimeout = core.getBooleanInput("continueOnTimeout", { required: false });
     const inputRepos = core.getInput("repos", { required: true });
     const workflowStartISOTimestamp = (/* @__PURE__ */ new Date()).toISOString();
     const octokit = github.getOctokit(token);
@@ -23160,9 +23161,15 @@ async function run() {
       if (oneWorkflowFailed) {
         throw new Error("\u{1F534}\u{1F534}\u{1F534} There were problems in some triggered workflows \u{1F534}\u{1F534}\u{1F534}");
       } else if (remainingWorkflowsMap.size > 0) {
-        throw new Error("\u{1F534}\u{1F534}\u{1F534} Some of the triggered workflow dispatches didnt finish in time or were not found \u{1F534}\u{1F534}\u{1F534}");
+        if (continueOnTimeout) {
+          const remaining = Array.from(remainingWorkflowsMap.keys()).join(", ");
+          core.info(`Timeout reached. Continuing as continueOnTimeout is true. Workflows still running: ${remaining}`);
+        } else {
+          throw new Error("\u{1F534}\u{1F534}\u{1F534} Some of the triggered workflow dispatches didnt finish in time or were not found \u{1F534}\u{1F534}\u{1F534}");
+        }
+      } else {
+        core.info(`\u2705\u2705\u2705 All triggered jobs finished successfully \u2705\u2705\u2705`);
       }
-      core.info(`\u2705\u2705\u2705 All triggered jobs finished successfully \u2705\u2705\u2705`);
     }
     const repos = await parseRepos(inputRepos);
     await triggerRepoWorkflows(repos);

--- a/github-trigger-workflows-and-wait/src/index.ts
+++ b/github-trigger-workflows-and-wait/src/index.ts
@@ -23,6 +23,7 @@ async function run() {
     const workflowName = core.getInput("workflowName", { required: true });
     const waitTimeout = parseInt(core.getInput("waitTimeout", { required: false }));
     const checkInterval = parseInt(core.getInput("checkInterval", { required: false }));
+    const continueOnTimeout = core.getBooleanInput("continueOnTimeout", { required: false });
     const inputRepos = core.getInput("repos", { required: true });
     
     const workflowStartISOTimestamp = new Date().toISOString();
@@ -117,9 +118,16 @@ async function run() {
         throw new Error('🔴🔴🔴 There were problems in some triggered workflows 🔴🔴🔴');
       } 
       else if(remainingWorkflowsMap.size > 0) {
-        throw new Error('🔴🔴🔴 Some of the triggered workflow dispatches didnt finish in time or were not found 🔴🔴🔴');
+        if (continueOnTimeout) {
+          const remaining = Array.from(remainingWorkflowsMap.keys()).join(', ');
+          core.info(`Timeout reached. Continuing as continueOnTimeout is true. Workflows still running: ${remaining}`);
+        } else {
+          throw new Error('🔴🔴🔴 Some of the triggered workflow dispatches didnt finish in time or were not found 🔴🔴🔴');
+        }
       }
-      core.info(`✅✅✅ All triggered jobs finished successfully ✅✅✅`);
+      else {
+        core.info(`✅✅✅ All triggered jobs finished successfully ✅✅✅`);
+      }
     }
     
     const repos = await parseRepos(inputRepos);


### PR DESCRIPTION
…nd-wait

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces optional timeout behavior control for the action.
> 
> - Adds `continueOnTimeout` input in `action.yml` (boolean, default `false`) and reads it via `core.getBooleanInput` in `src/index.ts`
> - Updates workflow waiting logic to continue instead of failing when timeout is reached and workflows are still running if `continueOnTimeout` is true; failures within timeout still fail
> - Updates `README.md` with defaults, descriptions, and a behavior table for `continueOnTimeout`; clarifies `checkInterval` and `repos` descriptions
> - Rebuilds `dist/index.js` accordingly
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6feb32a29918fb908a030d88ab081ebf21d02c8e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->