### PR TITLE
PLT-2056: Fast-completing workflows not detected, incorrectly reports…

### DIFF
--- a/github-trigger-workflows-and-wait/action.yml
+++ b/github-trigger-workflows-and-wait/action.yml
@@ -24,6 +24,10 @@ inputs:
     description: 'If true, treat timeout as success instead of failure (workflow still running at timeout)'
     type: boolean
     default: false
+  debug:
+    description: 'Enable debug logging'
+    type: boolean
+    default: false
   repos:
     description: 'Repositories json object'
     required: true

--- a/github-trigger-workflows-and-wait/dist/index.js
+++ b/github-trigger-workflows-and-wait/dist/index.js
@@ -23085,7 +23085,7 @@ async function run() {
     const checkInterval = parseInt(core.getInput("checkInterval", { required: false }));
     const continueOnTimeout = core.getBooleanInput("continueOnTimeout", { required: false });
     const inputRepos = core.getInput("repos", { required: true });
-    const workflowStartISOTimestamp = (/* @__PURE__ */ new Date()).toISOString();
+    const debug = core.getBooleanInput("debug", { required: false });
     const octokit = github.getOctokit(token);
     async function parseRepos(repos2) {
       core.info(`Parsing repo list:${repos2} ...`);
@@ -23108,6 +23108,25 @@ async function run() {
       core.info(`\u2705 Successfully parsed repo list: ${JSON.stringify(repoList)}`);
       return repoList;
     }
+    async function getBaselineRunIds(repos2) {
+      core.info("\u{1F4CA} Getting baseline workflow run IDs before triggering...");
+      const baselines2 = await Promise.all(repos2.map(async ({ owner, repo, workflow_id }) => {
+        try {
+          const response = await octokit.rest.actions.listWorkflowRuns({
+            owner,
+            repo,
+            workflow_id,
+            per_page: 1
+          });
+          const latestRunId = response.data.workflow_runs.length > 0 ? response.data.workflow_runs[0].id : null;
+          core.info(`Baseline for ${owner}/${repo}: latest run ID = ${latestRunId || "none"}`);
+          return { owner, repo, workflow_id, latestRunId };
+        } catch (error2) {
+          throw new Error(`\u{1F534} Failed to get baseline for ${owner}/${repo}: ${error2.message}. Cannot proceed without baseline to reliably detect triggered workflow.`);
+        }
+      }));
+      return baselines2;
+    }
     async function triggerRepoWorkflows(repos2) {
       let success = true;
       core.info("\u23F3\u23F3\u23F3 Triggering workflows list: ");
@@ -23129,30 +23148,70 @@ async function run() {
       return success;
     }
     ;
-    async function waitForWorkflowStatuses(repos2) {
+    async function waitForWorkflowStatuses(baselines2) {
       let oneWorkflowFailed = false;
       let attemptNumber = 1;
-      const maxAttempts = Math.ceil(waitTimeout / checkInterval);
-      const remainingWorkflowsMap = new Map(repos2.map((repo) => [`${repo.owner}/${repo.repo}`, true]));
+      const maxAttempts = Math.ceil(waitTimeout / checkInterval) + 1;
+      const remainingWorkflowsMap = new Map(baselines2.map((baseline) => [`${baseline.owner}/${baseline.repo}`, true]));
       core.info("\u23F3\u23F3\u23F3 Waiting for workflows to report status ...");
       while (remainingWorkflowsMap.size > 0 && oneWorkflowFailed === false && attemptNumber <= maxAttempts) {
-        await sleep(checkInterval);
-        await Promise.all(repos2.map(async ({ owner, repo, workflow_id }) => {
+        if (attemptNumber > 1) {
+          await sleep(checkInterval);
+        }
+        await Promise.all(baselines2.map(async ({ owner, repo, workflow_id, latestRunId }) => {
           const noSuccessReportYet = remainingWorkflowsMap.get(`${owner}/${repo}`);
           if (!noSuccessReportYet) {
             return;
           }
-          const response = await octokit.rest.actions.listWorkflowRuns({ owner, repo, workflow_id, per_page: 10, created: `>${workflowStartISOTimestamp}` });
-          const desiredRun = response.data.workflow_runs.filter((run2) => run2.name?.includes(environment))[0];
-          if (!desiredRun) {
+          const response = await octokit.rest.actions.listWorkflowRuns({
+            owner,
+            repo,
+            workflow_id,
+            per_page: 10
+          });
+          if (debug) {
+            core.info(`DEBUG: Found ${response.data.workflow_runs.length} runs, baseline is ${latestRunId}`);
+            response.data.workflow_runs.forEach((run2) => {
+              core.info(`DEBUG: Run ID ${run2.id}, name: "${run2.name}", created: ${run2.created_at}, status: ${run2.status}`);
+            });
+          }
+          const newerRuns = response.data.workflow_runs.filter((run2) => {
+            return latestRunId === null || run2.id > latestRunId;
+          });
+          if (debug) {
+            core.info(`DEBUG: ${newerRuns.length} runs are newer than baseline ${latestRunId}`);
+          }
+          if (newerRuns.length === 0) {
             core.info(`\u23F3 Attempt number: ${attemptNumber}, Workflow has not yet started for ${owner}/${repo} ...`);
-          } else if (desiredRun.status != "completed") {
+            return;
+          }
+          newerRuns.sort((a, b) => {
+            const timeA = new Date(a.created_at).getTime();
+            const timeB = new Date(b.created_at).getTime();
+            return timeB - timeA;
+          });
+          const runMatchingEnvironment = newerRuns.find((run2) => {
+            const matches = run2.name?.includes(environment) || false;
+            if (debug) {
+              core.info(`DEBUG: Run ID ${run2.id}, name: "${run2.name}", matches environment "${environment}": ${matches}`);
+            }
+            return matches;
+          });
+          const desiredRun = runMatchingEnvironment || newerRuns[0];
+          if (debug) {
+            if (runMatchingEnvironment) {
+              core.info(`DEBUG: Using run ${desiredRun.id} that matches environment "${environment}"`);
+            } else {
+              core.info(`DEBUG: No run name matches environment "${environment}", using newest run ${desiredRun.id} (name: "${desiredRun.name}")`);
+            }
+          }
+          if (desiredRun.status != "completed") {
             core.info(`\u23F3 Attempt number: ${attemptNumber}, Workflow in progress with status: "${desiredRun.status}" for ${owner}/${repo}`);
           } else if (desiredRun.conclusion != "success") {
             core.info(`\u{1F534} Attempt number: ${attemptNumber}, Workflow finished with conclusion: "${desiredRun.conclusion}" for ${owner}/${repo}`);
             oneWorkflowFailed = true;
           } else {
-            core.info(`\u2705 Attempt number: ${attemptNumber}, Workflow status: "${desiredRun.status}" conclussion: "${desiredRun.conclusion}" for ${owner}/${repo}`);
+            core.info(`\u2705 Attempt number: ${attemptNumber}, Workflow status: "${desiredRun.status}" conclusion: "${desiredRun.conclusion}" for ${owner}/${repo}`);
             remainingWorkflowsMap.delete(`${owner}/${repo}`);
           }
         }));
@@ -23172,8 +23231,9 @@ async function run() {
       }
     }
     const repos = await parseRepos(inputRepos);
+    const baselines = await getBaselineRunIds(repos);
     await triggerRepoWorkflows(repos);
-    await waitForWorkflowStatuses(repos);
+    await waitForWorkflowStatuses(baselines);
   } catch (error2) {
     core.setFailed(error2.message);
   }

--- a/github-trigger-workflows-and-wait/src/index.ts
+++ b/github-trigger-workflows-and-wait/src/index.ts
@@ -1,6 +1,5 @@
 import * as core from "@actions/core";
 import * as github from "@actions/github";
-import { v4 as uuidv4 } from 'uuid';
 
 interface UnparsedRepo {
   repo: string;
@@ -10,6 +9,13 @@ interface ParsedRepo {
   owner: string
   repo: string
   workflow_id: number
+}
+
+interface RepoBaseline {
+  owner: string
+  repo: string
+  workflow_id: number
+  latestRunId: number | null
 }
 
 function sleep(seconds: number) {
@@ -25,8 +31,7 @@ async function run() {
     const checkInterval = parseInt(core.getInput("checkInterval", { required: false }));
     const continueOnTimeout = core.getBooleanInput("continueOnTimeout", { required: false });
     const inputRepos = core.getInput("repos", { required: true });
-    
-    const workflowStartISOTimestamp = new Date().toISOString();
+    const debug = core.getBooleanInput("debug", { required: false });
     
     const octokit = github.getOctokit(token);
 
@@ -55,6 +60,31 @@ async function run() {
       return repoList;
     }
 
+    async function getBaselineRunIds(repos:ParsedRepo[]): Promise<RepoBaseline[]> {
+      core.info('📊 Getting baseline workflow run IDs before triggering...');
+      const baselines = await Promise.all(repos.map(async ({owner, repo, workflow_id}) => {
+        try {
+          const response = await octokit.rest.actions.listWorkflowRuns({
+            owner,
+            repo,
+            workflow_id,
+            per_page: 1
+          });
+          const latestRunId = response.data.workflow_runs.length > 0 
+            ? response.data.workflow_runs[0].id 
+            : null;
+          core.info(`Baseline for ${owner}/${repo}: latest run ID = ${latestRunId || 'none'}`);
+          return { owner, repo, workflow_id, latestRunId };
+        } catch (error: any) {
+          // If baseline retrieval fails, we can't determine if latestRunId would be null (no previous runs)
+          // or a number (there were previous runs). Without knowing this, we can't reliably identify which run we triggered.
+          // Fail fast rather than risk false positive detection.
+          throw new Error(`🔴 Failed to get baseline for ${owner}/${repo}: ${error.message}. Cannot proceed without baseline to reliably detect triggered workflow.`);
+        }
+      }));
+      return baselines;
+    }
+
     async function triggerRepoWorkflows(repos:ParsedRepo[]) {
       let success = true
       core.info("⏳⏳⏳ Triggering workflows list: ");
@@ -80,27 +110,82 @@ async function run() {
       return success;
     };
 
-    async function waitForWorkflowStatuses(repos:ParsedRepo[]) {
+    async function waitForWorkflowStatuses(baselines:RepoBaseline[]) {
       let oneWorkflowFailed = false;
       let attemptNumber = 1;
-      const maxAttempts = Math.ceil(waitTimeout/checkInterval);
-      const remainingWorkflowsMap = new Map(repos.map(repo => [`${repo.owner}/${repo.repo}`, true]));
+      // Add 1 to account for the immediate first check (no sleep before it)
+      // This ensures we monitor for the full waitTimeout duration
+      const maxAttempts = Math.ceil(waitTimeout/checkInterval) + 1;
+      const remainingWorkflowsMap = new Map(baselines.map(baseline => [`${baseline.owner}/${baseline.repo}`, true]));
 
       core.info('⏳⏳⏳ Waiting for workflows to report status ...');
       while(remainingWorkflowsMap.size > 0 && oneWorkflowFailed === false && attemptNumber<=maxAttempts) {
-        await sleep(checkInterval);
-        await Promise.all(repos.map(async ({owner, repo, workflow_id}) => {
-          // Skip checking for workflow status check if it already reported successfull
+        if (attemptNumber > 1) {
+          await sleep(checkInterval);
+        }
+        
+        await Promise.all(baselines.map(async ({owner, repo, workflow_id, latestRunId}) => {
           const noSuccessReportYet = remainingWorkflowsMap.get(`${owner}/${repo}`);
           if(!noSuccessReportYet) {
             return;
           }
-          const response = await octokit.rest.actions.listWorkflowRuns({owner, repo, workflow_id, per_page:10, created: `>${workflowStartISOTimestamp}`});
-          const desiredRun = response.data.workflow_runs.filter((run)=>run.name?.includes(environment))[0];
-          if(!desiredRun){
-            core.info(`⏳ Attempt number: ${attemptNumber}, Workflow has not yet started for ${owner}/${repo} ...`);
+          
+          const response = await octokit.rest.actions.listWorkflowRuns({
+            owner, 
+            repo, 
+            workflow_id, 
+            per_page: 10
+          });
+          
+          if (debug) {
+            core.info(`DEBUG: Found ${response.data.workflow_runs.length} runs, baseline is ${latestRunId}`);
+            response.data.workflow_runs.forEach((run) => {
+              core.info(`DEBUG: Run ID ${run.id}, name: "${run.name}", created: ${run.created_at}, status: ${run.status}`);
+            });
           }
-          else if (desiredRun.status != 'completed') {
+          
+          // Filter to runs that are newer than baseline
+          // Since we filtered by workflow_id and have a baseline, any run with higher ID is the one we triggered
+          const newerRuns = response.data.workflow_runs.filter((run) => {
+            return latestRunId === null || run.id > latestRunId;
+          });
+          
+          if (debug) {
+            core.info(`DEBUG: ${newerRuns.length} runs are newer than baseline ${latestRunId}`);
+          }
+          
+          if (newerRuns.length === 0) {
+            core.info(`⏳ Attempt number: ${attemptNumber}, Workflow has not yet started for ${owner}/${repo} ...`);
+            return;
+          }
+          
+          newerRuns.sort((a, b) => {
+            const timeA = new Date(a.created_at).getTime();
+            const timeB = new Date(b.created_at).getTime();
+            return timeB - timeA;
+          });
+          
+          // Prefer runs matching environment name, but use newest if none match
+          // (The run name may not include the environment, so we can't require it)
+          const runMatchingEnvironment = newerRuns.find((run) => {
+            const matches = run.name?.includes(environment) || false;
+            if (debug) {
+              core.info(`DEBUG: Run ID ${run.id}, name: "${run.name}", matches environment "${environment}": ${matches}`);
+            }
+            return matches;
+          });
+          
+          const desiredRun = runMatchingEnvironment || newerRuns[0];
+          
+          if (debug) {
+            if (runMatchingEnvironment) {
+              core.info(`DEBUG: Using run ${desiredRun.id} that matches environment "${environment}"`);
+            } else {
+              core.info(`DEBUG: No run name matches environment "${environment}", using newest run ${desiredRun.id} (name: "${desiredRun.name}")`);
+            }
+          }
+          
+          if (desiredRun.status != 'completed') {
             core.info(`⏳ Attempt number: ${attemptNumber}, Workflow in progress with status: "${desiredRun.status}" for ${owner}/${repo}`);
           }
           else if (desiredRun.conclusion != 'success') {
@@ -108,11 +193,12 @@ async function run() {
             oneWorkflowFailed = true;
           }
           else {
-            core.info(`✅ Attempt number: ${attemptNumber}, Workflow status: "${desiredRun.status}" conclussion: "${desiredRun.conclusion}" for ${owner}/${repo}`);
+            core.info(`✅ Attempt number: ${attemptNumber}, Workflow status: "${desiredRun.status}" conclusion: "${desiredRun.conclusion}" for ${owner}/${repo}`);
             remainingWorkflowsMap.delete(`${owner}/${repo}`);
           }
         }));
-        attemptNumber+=1;
+        
+        attemptNumber += 1;
       }
       if(oneWorkflowFailed){
         throw new Error('🔴🔴🔴 There were problems in some triggered workflows 🔴🔴🔴');
@@ -131,8 +217,9 @@ async function run() {
     }
     
     const repos = await parseRepos(inputRepos);
+    const baselines = await getBaselineRunIds(repos);
     await triggerRepoWorkflows(repos);
-    await waitForWorkflowStatuses(repos);
+    await waitForWorkflowStatuses(baselines);
   } catch (error: any) {
     core.setFailed(error.message);
   }

--- a/github-trigger-workflows-and-wait/src/index.ts
+++ b/github-trigger-workflows-and-wait/src/index.ts
@@ -145,7 +145,7 @@ async function run() {
           }
           
           // Filter to runs that are newer than baseline
-          // Since we filtered by workflow_id and have a baseline, any run with higher ID is the one we triggered
+          // Since we filtered by workflow_id and have a baseline, any run with higher ID could be the one we triggered
           const newerRuns = response.data.workflow_runs.filter((run) => {
             return latestRunId === null || run.id > latestRunId;
           });


### PR DESCRIPTION
… "Workflow has not yet started"

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fixes missed detections of fast-completing workflows by tracking baseline run IDs and monitoring only runs newer than that baseline.
> 
> - Capture per-repo baseline `latestRunId` before dispatch; poll runs newer than baseline, prefer those matching `environment`, else use newest
> - Adjust wait loop to check immediately (no initial sleep) and account for full timeout; clean up logs and message typo
> - Add `debug` input in `action.yml` and conditional verbose logging in runtime
> - Remove timestamp-based run filtering and unused code
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e04406e58d5979f849b8c1395b1e4bef298d2d1e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->