### PR TITLE
PLT-2057: add cleanup-java action to remove ECR environment tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,9 @@ Re-usable GitHub Actions
 
 ### Composite Actions
 
-- deployment-status
+- build-java
+- cleanup-java
+- deploy-java
 - jira-deployment-status
 - slack-deployment-status
 - sync-image-between-ecrs
@@ -27,6 +29,8 @@ Re-usable GitHub Actions
 - github-trigger-workflows-and-wait
 - jira-environment-revision-search
 - jira-environment-revision-set
+- jira-environment-ticket-create
+- jira-environment-ticket-delete
 - jira-issues-from-commits
 - jira-issues-update-fix-version
 - jira-project-version-create

--- a/cleanup-java/action.yml
+++ b/cleanup-java/action.yml
@@ -1,0 +1,81 @@
+name: 'Cleanup Java'
+description: 'Cleanup tasks for Java service (e.g., remove ECR environment tag)'
+inputs:
+  appName:
+    description: 'Name of the app and matching project field'
+    required: true
+  environmentTag:
+    description: 'Docker tag to remove from the image'
+    required: true
+  roleToAssumeForEcr:
+    description: 'AWS Role to Assume for access to ECR'
+    required: true
+
+runs:
+  using: "composite"
+  steps:
+    - name: Configure AWS Credentials
+      uses: aws-actions/configure-aws-credentials@v5
+      with:
+        role-to-assume: ${{ inputs.roleToAssumeForEcr }}
+        aws-region: us-west-2
+
+    - name: Remove environment tag from ECR
+      shell: bash
+      run: |
+        echo "Removing ECR tag '${{ inputs.environmentTag }}' from '${{ inputs.appName }}'..."
+        # batch-delete-image removes the tag if the image has multiple tags (image is preserved).
+        # If this is the last tag, it deletes the image (which also removes the tag).
+        # This is safe for our use case.
+        
+        # Capture stderr separately to avoid contaminating JSON output with AWS CLI warnings
+        # (stderr warnings would cause jq parse failures and mask real errors)
+        stderr_file=$(mktemp)
+        trap 'rm -f "$stderr_file"' EXIT
+        
+        output=$(aws ecr batch-delete-image \
+          --repository-name "${{ inputs.appName }}" \
+          --image-ids imageTag="${{ inputs.environmentTag }}" \
+          --region us-west-2 \
+          --output json 2>"$stderr_file")
+        exit_code=$?
+        
+        stderr_output=$(cat "$stderr_file")
+        
+        if [ $exit_code -ne 0 ]; then
+          # Check both stdout and stderr for expected "not found" errors
+          combined_output="$output $stderr_output"
+          if echo "$combined_output" | grep -qiE "(ImageNotFoundException|RepositoryNotFoundException)"; then
+            echo "Image or tag '${{ inputs.environmentTag }}' not found - continuing"
+            exit 0
+          else
+            echo "Error calling batch-delete-image (exit code $exit_code):"
+            [ -n "$stderr_output" ] && echo "stderr: $stderr_output"
+            [ -n "$output" ] && echo "stdout: $output"
+            exit $exit_code
+          fi
+        fi
+
+        # Check for failures in the response using jq (avoids pipefail issues with grep)
+        failure_count=$(echo "$output" | jq -r '.failures | length')
+        # Validate jq output - if parsing failed, failure_count won't be a number
+        if ! [[ "$failure_count" =~ ^[0-9]+$ ]]; then
+          echo "Error: Failed to parse AWS response as JSON"
+          [ -n "$stderr_output" ] && echo "stderr: $stderr_output"
+          echo "stdout: $output"
+          exit 1
+        fi
+        
+        if [ "$failure_count" -gt 0 ]; then
+          # Count failures that are NOT ImageNotFound (those are real errors)
+          non_image_not_found_count=$(echo "$output" | jq -r '[.failures[] | select(.failureCode != "ImageNotFound")] | length')
+          if [ "$non_image_not_found_count" -eq 0 ]; then
+            echo "Image or tag '${{ inputs.environmentTag }}' not found - continuing"
+            exit 0
+          fi
+          failure_details=$(echo "$output" | jq -r '.failures')
+          echo "Failed to remove tag: $failure_details"
+          exit 1
+        fi
+
+        echo "Successfully removed tag '${{ inputs.environmentTag }}'"

--- a/cleanup-java/action.yml
+++ b/cleanup-java/action.yml
@@ -22,8 +22,11 @@ runs:
 
     - name: Remove environment tag from ECR
       shell: bash
+      env:
+        APP_NAME: ${{ inputs.appName }}
+        ENVIRONMENT_TAG: ${{ inputs.environmentTag }}
       run: |
-        echo "Removing ECR tag '${{ inputs.environmentTag }}' from '${{ inputs.appName }}'..."
+        echo "Removing ECR tag '$ENVIRONMENT_TAG' from '$APP_NAME'..."
         # batch-delete-image removes the tag if the image has multiple tags (image is preserved).
         # If this is the last tag, it deletes the image (which also removes the tag).
         # This is safe for our use case.
@@ -34,8 +37,8 @@ runs:
         trap 'rm -f "$stderr_file"' EXIT
         
         output=$(aws ecr batch-delete-image \
-          --repository-name "${{ inputs.appName }}" \
-          --image-ids imageTag="${{ inputs.environmentTag }}" \
+          --repository-name "$APP_NAME" \
+          --image-ids imageTag="$ENVIRONMENT_TAG" \
           --region us-west-2 \
           --output json 2>"$stderr_file")
         exit_code=$?
@@ -46,7 +49,7 @@ runs:
           # Check both stdout and stderr for expected "not found" errors
           combined_output="$output $stderr_output"
           if echo "$combined_output" | grep -qiE "(ImageNotFoundException|RepositoryNotFoundException)"; then
-            echo "Image or tag '${{ inputs.environmentTag }}' not found - continuing"
+            echo "Image or tag '$ENVIRONMENT_TAG' not found - continuing"
             exit 0
           else
             echo "Error calling batch-delete-image (exit code $exit_code):"
@@ -70,7 +73,7 @@ runs:
           # Count failures that are NOT ImageNotFound (those are real errors)
           non_image_not_found_count=$(echo "$output" | jq -r '[.failures[] | select(.failureCode != "ImageNotFound")] | length')
           if [ "$non_image_not_found_count" -eq 0 ]; then
-            echo "Image or tag '${{ inputs.environmentTag }}' not found - continuing"
+            echo "Image or tag '$ENVIRONMENT_TAG' not found - continuing"
             exit 0
           fi
           failure_details=$(echo "$output" | jq -r '.failures')
@@ -78,4 +81,4 @@ runs:
           exit 1
         fi
 
-        echo "Successfully removed tag '${{ inputs.environmentTag }}'"
+        echo "Successfully removed tag '$ENVIRONMENT_TAG'"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds a new composite action for cleaning up Java service ECR tags and updates action listings in the README.
> 
> - **New composite action** `cleanup-java/action.yml`: removes ECR `environmentTag` from `appName` using `aws ecr batch-delete-image`, with assumed role via `aws-actions/configure-aws-credentials@v5` and robust stderr/JSON handling for not-found and failure cases
> - **README updates**: lists new composite actions (`build-java`, `cleanup-java`, `deploy-java`) and new Typescript actions (`jira-environment-ticket-create`, `jira-environment-ticket-delete`)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 60011366408358eae598da5e42fa7c0e74977dc3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->