### PR TITLE
IM-99 - Add support for prod3

### DIFF
--- a/.github/workflows/shared-sync-environment-variables.yml
+++ b/.github/workflows/shared-sync-environment-variables.yml
@@ -45,7 +45,7 @@ jobs:
           token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
 
   sync-prod-3:
-    name: Sync APAC Prod Environment Variables
+    name: Sync Singapore/Backup Prod Environment Variables
     runs-on: ubuntu-latest
     permissions:
       id-token: write

--- a/.github/workflows/shared-sync-environment-variables.yml
+++ b/.github/workflows/shared-sync-environment-variables.yml
@@ -43,3 +43,21 @@ jobs:
         uses: cartoncloud/actions/aws-environment-param-sync@v3
         with:
           token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+
+  sync-prod-3:
+    name: Sync APAC Prod Environment Variables
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v5
+        with:
+          role-to-assume: ${{ vars.AWS_ROLE_CARTONCLOUD_APP_PROD }}
+          aws-region: ${{ vars.SERVICES_PROD_3_REGION }}
+
+      - name: Sync Param Store with Environment Variables
+        uses: cartoncloud/actions/aws-environment-param-sync@v3
+        with:
+          token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk workflow-only change that adds an additional GitHub Actions job; main risk is misconfigured `SERVICES_PROD_3_REGION`/AWS role causing sync failures or unintended parameter updates in the new region.
> 
> **Overview**
> Adds a new `sync-prod-3` job to `shared-sync-environment-variables.yml` to sync production environment variables for the Singapore/backup prod region.
> 
> The new job mirrors the existing prod sync flow, assuming the prod AWS role and running `cartoncloud/actions/aws-environment-param-sync@v3` against `vars.SERVICES_PROD_3_REGION`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c9e3b3ca11acbbdeb4c4ce6239dae560fd334ca4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->