### PR TITLE
Jira issues should not block the release

### DIFF
--- a/.github/workflows/shared-release-pull-request-java.yml
+++ b/.github/workflows/shared-release-pull-request-java.yml
@@ -72,6 +72,7 @@ jobs:
 
       - name: Get JIRA issues from commits
         id: jira-issues-from-commits
+        continue-on-error: true
         uses: cartoncloud/actions/jira-issues-from-commits@v3
         with:
           jiraServer: ${{ vars.JIRA_SERVER }}
@@ -102,6 +103,7 @@ jobs:
 
       - name: Generate Markdown release notes
         id: release-notes-markdown
+        continue-on-error: true
         uses: cartoncloud/actions/jira-release-notes-markdown@v3
         with:
           title: 'Release ${{ steps.increment-version.outputs.new_tag }}-${{ steps.sha.outputs.short-sha }} (#${{ github.event.pull_request.number }})'
@@ -316,6 +318,7 @@ jobs:
 
       - name: Get JIRA issues from commits
         id: jira-issues-from-commits
+        continue-on-error: true
         uses: cartoncloud/actions/jira-issues-from-commits@v3
         with:
           jiraServer: ${{ vars.JIRA_SERVER }}
@@ -339,10 +342,12 @@ jobs:
 
       - name: Generate Markdown release notes
         id: release-notes-markdown
+        continue-on-error: true
         uses: cartoncloud/actions/jira-release-notes-markdown@v3
 
       - name: Generate Slack release notes
         id: release-notes-slack
+        continue-on-error: true
         uses: cartoncloud/actions/jira-release-notes-slack@v3
         with:
           title: ${{ inputs.appName }} ${{ steps.increment-version.outputs.new_tag }}
@@ -363,6 +368,7 @@ jobs:
 
       - name: Create JIRA Release
         id: create-jira-release
+        continue-on-error: true
         uses: cartoncloud/actions/jira-project-version-create@v3
         with:
           username: ${{ secrets.JIRA_USERNAME }}
@@ -374,6 +380,7 @@ jobs:
           isReleased: false
 
       - name: Update JIRA fix versions
+        continue-on-error: true
         uses: cartoncloud/actions/jira-issues-update-fix-version@v3
         with:
           jiraServer: ${{ vars.JIRA_SERVER }}
@@ -441,6 +448,7 @@ jobs:
           clusterName: ${{ vars.CLUSTER_NAME || '' }}
 
       - name: Mark JIRA as released
+        continue-on-error: true
         uses: cartoncloud/actions/jira-project-version-update@v3
         with:
           username: ${{ secrets.JIRA_USERNAME }}

--- a/.github/workflows/shared-release-pull-request-java.yml
+++ b/.github/workflows/shared-release-pull-request-java.yml
@@ -89,7 +89,7 @@ jobs:
           WITH_V: true
           DRY_RUN: true
           RELEASE_BRANCHES: .*
-          DEFAULT_BUMP: ${{ steps.jira-issues-from-commits.outputs.suggestedVersionBump }}
+          DEFAULT_BUMP: ${{ steps.jira-issues-from-commits.outputs.suggestedVersionBump || 'patch' }}
           VERBOSE: false
           INITIAL_VERSION: ${{ inputs.initialVersion }}
 
@@ -109,7 +109,7 @@ jobs:
           title: 'Release ${{ steps.increment-version.outputs.new_tag }}-${{ steps.sha.outputs.short-sha }} (#${{ github.event.pull_request.number }})'
 
       - name: Update pull request description (main release)
-        if: ${{ github.event.pull_request.head.ref == 'release/production' }}
+        if: ${{ github.event.pull_request.head.ref == 'release/production' && steps.release-notes-markdown.outputs.releaseNotes != '' }}
         run: |
           gh pr edit $PR --body "$BODY
           ---
@@ -120,7 +120,7 @@ jobs:
           BODY: ${{ steps.release-notes-markdown.outputs.releaseNotes }}
 
       - name: Update pull request description (hotfix)
-        if: ${{ github.event.pull_request.head.ref != 'release/production' }}
+        if: ${{ github.event.pull_request.head.ref != 'release/production' && steps.release-notes-markdown.outputs.releaseNotes != '' }}
         run: |
           gh pr edit $PR --body "$BODY
           ---
@@ -335,7 +335,7 @@ jobs:
           WITH_V: true
           DRY_RUN: false
           RELEASE_BRANCHES: .*
-          DEFAULT_BUMP: ${{ steps.jira-issues-from-commits.outputs.suggestedVersionBump }}
+          DEFAULT_BUMP: ${{ steps.jira-issues-from-commits.outputs.suggestedVersionBump || 'patch' }}
           VERBOSE: false
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           INITIAL_VERSION: ${{ inputs.initialVersion }}
@@ -380,6 +380,7 @@ jobs:
           isReleased: false
 
       - name: Update JIRA fix versions
+        if: steps.create-jira-release.outputs.releaseId != ''
         continue-on-error: true
         uses: cartoncloud/actions/jira-issues-update-fix-version@v3
         with:
@@ -448,6 +449,7 @@ jobs:
           clusterName: ${{ vars.CLUSTER_NAME || '' }}
 
       - name: Mark JIRA as released
+        if: needs.create-releases.outputs.jiraReleaseId != ''
         continue-on-error: true
         uses: cartoncloud/actions/jira-project-version-update@v3
         with:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Workflow-only changes that mainly relax failure behavior around external JIRA integrations; risk is limited to potentially missing/partial release notes or JIRA metadata updates.
> 
> **Overview**
> Makes the Java release PR GitHub Actions workflow resilient to JIRA-related failures by marking JIRA issue extraction, release note generation, and JIRA release creation/update steps as `continue-on-error`.
> 
> Adds safe fallbacks/guards: defaults version bump to `patch` when no JIRA bump is produced, only edits PR bodies when release notes are non-empty, and only updates JIRA fix versions / marks JIRA released when a `jiraReleaseId` is available.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4ce19e8a1fd3627548d115f33a3dd5f3018bc6d4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->