### PR TITLE
PLT-2119 add staging variables syncing

### DIFF
--- a/.github/workflows/shared-sync-environment-variables.yml
+++ b/.github/workflows/shared-sync-environment-variables.yml
@@ -25,6 +25,24 @@ jobs:
         with:
           token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
 
+  sync-staging:
+    name: Sync Staging Environment Variables
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v5
+        with:
+          role-to-assume: ${{ vars.AWS_ROLE_CARTONCLOUD_APP_STAGING }}
+          aws-region: ${{ vars.SERVICES_STAGING_REGION }}
+
+      - name: Sync Param Store with Environment Variables
+        uses: cartoncloud/actions/aws-environment-param-sync@v3
+        with:
+          token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+
 
   sync-prod-2:
     name: Sync NA Prod Environment Variables


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Workflow-only change that adds a new staging sync job; main risk is misconfigured AWS role/region or action version mismatch causing staging sync failures.
> 
> **Overview**
> Adds a new `sync-staging` job to the shared `shared-sync-environment-variables.yml` workflow to sync staging AWS Parameter Store values to GitHub environment variables using `AWS_ROLE_CARTONCLOUD_APP_STAGING` and `SERVICES_STAGING_REGION`.
> 
> Other existing sync jobs remain unchanged; staging uses `aws-actions/configure-aws-credentials@v5` while the other environments use `@v6`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ecd3d2af081ff135055e231f6db9b9a3a7997836. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->