### PR TITLE
PLT-2123: invalid if expression syntax warning

### DIFF
--- a/.github/workflows/shared-environment-re-target-java.yml
+++ b/.github/workflows/shared-environment-re-target-java.yml
@@ -29,7 +29,7 @@ jobs:
   re-target-list:
     name: Environment Updates
     runs-on: ubuntu-latest
-    if: ${{ inputs.prMerged }} && ${{ inputs.prHeadRepoId }} == ${{ inputs.prBaseRepoId }} && ${{ inputs.prBaseRef }} == 'main'
+    if: ${{ inputs.prMerged && inputs.prHeadRepoId == inputs.prBaseRepoId && inputs.prBaseRef == 'main' }}
 
     outputs:
       environments: ${{ steps.find-issues.outputs.environments }}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Single-line CI workflow expression change with no impact to application code; risk is limited to job gating behavior if the condition was previously mis-evaluated.
> 
> **Overview**
> Fixes the `if:` condition syntax in `shared-environment-re-target-java.yml` by consolidating multiple `${{ }}` blocks into a single GitHub Actions expression.
> 
> This removes the workflow warning while keeping the job gated to run only for merged PRs from the same repo targeting `main`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 74b08560572b4913a9563421d5eb3b3d12b367dc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->