### PR TITLE
[Technical] CC-42264 - break release notes into smaller chunks when over max size

### DIFF
--- a/jira-release-notes-slack/dist/index.js
+++ b/jira-release-notes-slack/dist/index.js
@@ -28936,11 +28936,11 @@ function splitTextIntoBlocks(text, maxLength = SLACK_MAX_TEXT_LENGTH) {
   let remaining = text;
   while (remaining.length > maxLength) {
     let splitPoint = maxLength;
-    const newlineIndex = remaining.lastIndexOf("\n", maxLength);
+    const newlineIndex = remaining.lastIndexOf("\n", maxLength - 1);
     if (newlineIndex > maxLength * 0.7) {
       splitPoint = newlineIndex + 1;
     } else {
-      const spaceIndex = remaining.lastIndexOf(" ", maxLength);
+      const spaceIndex = remaining.lastIndexOf(" ", maxLength - 1);
       if (spaceIndex > maxLength * 0.7) {
         splitPoint = spaceIndex + 1;
       }
@@ -29046,7 +29046,7 @@ async function generate({ title, issues, otherCommits, slackToken, repoUrl }) {
       const testText = `${currentBlockText}
 ${bullet}`;
       if (testText.length > SLACK_MAX_TEXT_LENGTH) {
-        if (currentBlockText !== header) {
+        if (currentBlockText) {
           blocks.push(currentBlockText);
         }
         currentBlockText = bullet;

--- a/jira-release-notes-slack/dist/index.js
+++ b/jira-release-notes-slack/dist/index.js
@@ -28927,6 +28927,44 @@ function fixResponseChunkedTransferBadEnding(request, errorCallback) {
 
 // src/generate.ts
 var core = __toESM(require_core());
+var SLACK_MAX_TEXT_LENGTH = 3e3;
+function splitTextIntoBlocks(text, maxLength = SLACK_MAX_TEXT_LENGTH) {
+  if (text.length <= maxLength) {
+    return [text];
+  }
+  const blocks = [];
+  let remaining = text;
+  while (remaining.length > maxLength) {
+    let splitPoint = maxLength;
+    const newlineIndex = remaining.lastIndexOf("\n", maxLength);
+    if (newlineIndex > maxLength * 0.7) {
+      splitPoint = newlineIndex + 1;
+    } else {
+      const spaceIndex = remaining.lastIndexOf(" ", maxLength);
+      if (spaceIndex > maxLength * 0.7) {
+        splitPoint = spaceIndex + 1;
+      }
+    }
+    blocks.push(remaining.substring(0, splitPoint));
+    remaining = remaining.substring(splitPoint);
+  }
+  if (remaining.length > 0) {
+    blocks.push(remaining);
+  }
+  return blocks;
+}
+function addSectionBlocks(message, text) {
+  const textBlocks = splitTextIntoBlocks(text);
+  for (const blockText of textBlocks) {
+    message.blocks.push({
+      type: "section",
+      text: {
+        type: "mrkdwn",
+        text: blockText
+      }
+    });
+  }
+}
 async function getSlackUserId({ email, token }) {
   const response = await fetch(`https://slack.com/api/users.lookupByEmail?&email=${email}`, {
     method: "GET",
@@ -28990,37 +29028,38 @@ async function generate({ title, issues, otherCommits, slackToken, repoUrl }) {
     const jiraKey = `<${issue.htmlUrl}|${issue.key}>`;
     const reporter = issue.fields.reporter?.emailAddress ? emailsToUser[issue.fields.reporter.emailAddress] : "_No Reporter_";
     const assignee = issue.fields.assignee?.emailAddress ? emailsToUser[issue.fields.assignee.emailAddress] : "_Unassigned_";
-    slackMessage.blocks.push(
-      {
-        type: "section",
-        text: {
-          type: "mrkdwn",
-          text: `${blockPrefix}\u2022 ${jiraKey} ${summary}
-	${reporter}	${assignee}`
-        }
-      }
-    );
+    const fullText = `${blockPrefix}\u2022 ${jiraKey} ${summary}
+	${reporter}	${assignee}`;
+    addSectionBlocks(slackMessage, fullText);
   }
   if (issues.length === 0) {
     core.warning("No Jira changes found");
-    slackMessage.blocks.push({
-      type: "section",
-      text: {
-        type: "mrkdwn",
-        text: "_No Jira changes found_"
-      }
-    });
+    addSectionBlocks(slackMessage, "_No Jira changes found_");
   }
   if (otherCommits.length > 0) {
     const commitUrl = `${repoUrl}/commit`;
     const commitBullets = otherCommits.map((it) => `\u2022 <${commitUrl}/${it.shortHash}|${it.shortHash}> ${it.message}`);
-    slackMessage.blocks.push({
-      type: "section",
-      text: {
-        type: "mrkdwn",
-        text: ["*Other Commits*", ...commitBullets].join("\n")
+    const header = "*Other Commits*";
+    const blocks = [];
+    let currentBlockText = header;
+    for (const bullet of commitBullets) {
+      const testText = `${currentBlockText}
+${bullet}`;
+      if (testText.length > SLACK_MAX_TEXT_LENGTH) {
+        if (currentBlockText !== header) {
+          blocks.push(currentBlockText);
+        }
+        currentBlockText = bullet;
+      } else {
+        currentBlockText = testText;
       }
-    });
+    }
+    if (currentBlockText) {
+      blocks.push(currentBlockText);
+    }
+    for (const blockText of blocks) {
+      addSectionBlocks(slackMessage, blockText);
+    }
   }
   if (slackMessage.blocks.length > 50) {
     slackMessage.blocks = slackMessage.blocks.slice(0, 49);

--- a/jira-release-notes-slack/src/generate.test.ts
+++ b/jira-release-notes-slack/src/generate.test.ts
@@ -261,8 +261,10 @@ describe('generate', () => {
 
     // Find all "Other Commits" blocks
     const commitBlocks = result.blocks.filter((block: any) => 
-      block.type === 'section' && block.text?.text?.includes('Other Commits') || 
-      block.text?.text?.match(/• <https:\/\/github\.com\/myorg\/myrepo\/commit\/a\d{7}\|a\d{7}>/)
+      block.type === 'section' && (
+        block.text?.text?.includes('Other Commits') || 
+        block.text?.text?.match(/• <https:\/\/github\.com\/myorg\/myrepo\/commit\/a\d{7}\|a\d{7}>/)
+      )
     );
     
     // Should have multiple blocks if the content is long enough

--- a/jira-release-notes-slack/src/generate.test.ts
+++ b/jira-release-notes-slack/src/generate.test.ts
@@ -434,7 +434,7 @@ describe('generate', () => {
     );
     
     // Should have at least 2 blocks: one with header, one with the commit
-    expect(commitBlocks.length).toBeGreaterThanOrEqual(1);
+    expect(commitBlocks.length).toBeGreaterThanOrEqual(2);
     
     // Verify that the header "*Other Commits*" is present in at least one block
     const combinedText = commitBlocks.map((block: any) => block.text.text).join('');

--- a/jira-release-notes-slack/src/generate.test.ts
+++ b/jira-release-notes-slack/src/generate.test.ts
@@ -196,4 +196,86 @@ describe('generate', () => {
       ],
     });
   });
+
+  it('splits long issue summaries into multiple blocks', async () => {
+    // Create an issue with a summary that would exceed 3000 characters
+    const longSummary = 'A'.repeat(4000);
+    const issues = [{
+      "key": "CC-99999",
+      "fields": {
+        "assignee": { "emailAddress": "test@example.com", "displayName": "Test User" },
+        "reporter": { "emailAddress": "test@example.com", "displayName": "Test User" },
+        "issuetype": { "name": "Story", "markdownEmoji": ":book:" },
+        "summary": longSummary
+      },
+      "htmlUrl": "https://support.example.com/browse/CC-99999"
+    }];
+    
+    const result = await generate({
+      title: 'Test',
+      issues: issues,
+      otherCommits: [],
+      slackToken: '',
+      repoUrl: 'https://github.com/myorg/myrepo',
+    });
+
+    // Find all section blocks (excluding the context block and "No Jira changes" block)
+    const sectionBlocks = result.blocks.filter((block: any) => 
+      block.type === 'section' && 
+      !block.text?.text?.includes('No Jira changes found')
+    );
+    
+    // Should have multiple blocks since the summary is long
+    // The full text with prefix and footer should be: ~18 (prefix) + ~60 (key) + 4000 (summary) + ~30 (footer) = ~4108 chars
+    // So it should split into at least 2 blocks
+    expect(sectionBlocks.length).toBeGreaterThan(1);
+    
+    // Verify that each block doesn't exceed 3000 characters
+    sectionBlocks.forEach((block: any) => {
+      expect(block.text.text.length).toBeLessThanOrEqual(3000);
+    });
+    
+    // Verify that all content is preserved (no truncation)
+    // The first block should contain the issue key
+    expect(sectionBlocks[0].text.text).toContain('CC-99999');
+    
+    // Combined text should contain the full summary length
+    const combinedText = sectionBlocks.map((block: any) => block.text.text).join('');
+    expect(combinedText.length).toBeGreaterThan(4000); // Should contain the full summary
+  });
+
+  it('splits long commit lists into multiple blocks', async () => {
+    // Create many commits that would exceed 3000 characters when combined
+    const otherCommits = Array.from({ length: 100 }, (_, i) => ({
+      "shortHash": `a${i.toString().padStart(7, '0')}`,
+      "message": `This is a commit message ${i} that is reasonably long to test the splitting functionality`
+    }));
+    
+    const result = await generate({
+      title: 'Test',
+      issues: [],
+      otherCommits: otherCommits,
+      slackToken: '',
+      repoUrl: 'https://github.com/myorg/myrepo',
+    });
+
+    // Find all "Other Commits" blocks
+    const commitBlocks = result.blocks.filter((block: any) => 
+      block.type === 'section' && block.text?.text?.includes('Other Commits') || 
+      block.text?.text?.match(/• <https:\/\/github\.com\/myorg\/myrepo\/commit\/a\d{7}\|a\d{7}>/)
+    );
+    
+    // Should have multiple blocks if the content is long enough
+    expect(commitBlocks.length).toBeGreaterThan(1);
+    
+    // Each block should not exceed 3000 characters
+    commitBlocks.forEach((block: any) => {
+      expect(block.text.text.length).toBeLessThanOrEqual(3000);
+    });
+    
+    // Verify that all commits are preserved (check for first and last commit)
+    const combinedText = commitBlocks.map((block: any) => block.text.text).join('');
+    expect(combinedText).toContain('a0000000'); // First commit
+    expect(combinedText).toContain('a0000099'); // Last commit
+  });
 });

--- a/jira-release-notes-slack/src/generate.test.ts
+++ b/jira-release-notes-slack/src/generate.test.ts
@@ -278,4 +278,53 @@ describe('generate', () => {
     expect(combinedText).toContain('a0000000'); // First commit
     expect(combinedText).toContain('a0000099'); // Last commit
   });
+
+  it('truncates blocks when exceeding 50 block limit', async () => {
+    // Create enough issues to exceed 50 blocks
+    // Each issue creates at least 1 block, so 60 issues should create more than 50 blocks
+    const issues = Array.from({ length: 60 }, (_, i) => ({
+      "key": `CC-${i.toString().padStart(5, '0')}`,
+      "fields": {
+        "assignee": { "emailAddress": "test@example.com", "displayName": "Test User" },
+        "reporter": { "emailAddress": "test@example.com", "displayName": "Test User" },
+        "issuetype": { "name": "Story", "markdownEmoji": ":book:" },
+        "summary": `Issue ${i} summary`
+      },
+      "htmlUrl": `https://support.example.com/browse/CC-${i.toString().padStart(5, '0')}`
+    }));
+    
+    const result = await generate({
+      title: 'Test',
+      issues: issues,
+      otherCommits: [],
+      slackToken: '',
+      repoUrl: 'https://github.com/myorg/myrepo',
+    });
+
+    // Should have exactly 50 blocks total (1 context title + 48 issue blocks + 1 truncation message)
+    expect(result.blocks.length).toBe(50);
+    
+    // The last block should be the truncation message
+    const lastBlock = result.blocks[result.blocks.length - 1];
+    expect(lastBlock.type).toBe('context');
+    expect(lastBlock.elements[0].text).toBe('_Release notes have been truncated as they exceed the maximum length_');
+    
+    // The first block should be the context block with title
+    expect(result.blocks[0].type).toBe('context');
+    
+    // The remaining 48 blocks (blocks 1-48) should be section blocks with issues
+    for (let i = 1; i < 49; i++) {
+      expect(result.blocks[i].type).toBe('section');
+      expect(result.blocks[i].text.type).toBe('mrkdwn');
+    }
+    
+    // Verify that some early issues are included
+    const combinedText = result.blocks.slice(1, 49).map((block: any) => block.text.text).join('');
+    expect(combinedText).toContain('CC-00000'); // First issue
+    expect(combinedText).toContain('CC-00047'); // Last issue in truncated list (48 issues total)
+    
+    // Verify that later issues are not included (truncated)
+    expect(combinedText).not.toContain('CC-00048');
+    expect(combinedText).not.toContain('CC-00059');
+  });
 });

--- a/jira-release-notes-slack/src/generate.test.ts
+++ b/jira-release-notes-slack/src/generate.test.ts
@@ -405,4 +405,45 @@ describe('generate', () => {
     expect(combinedText).not.toContain('CC-00048');
     expect(combinedText).not.toContain('CC-00059');
   });
+
+  it('preserves header when first commit bullet exceeds limit with header', async () => {
+    // Create a commit message that, when combined with the header, exceeds 3000 characters
+    // Header "*Other Commits*" is 16 chars, plus "\n" is 1 char, so we need a commit > 2983 chars
+    const longCommitMessage = 'A'.repeat(3000); // This will make header + "\n" + commit > 3000
+    const otherCommits = [{
+      "shortHash": "abc1234",
+      "message": longCommitMessage
+    }];
+    
+    const result = await generate({
+      title: 'Test',
+      issues: [],
+      otherCommits: otherCommits,
+      slackToken: '',
+      repoUrl: 'https://github.com/myorg/myrepo',
+    });
+
+    // Find all "Other Commits" blocks
+    const commitBlocks = result.blocks.filter((block: any) => 
+      block.type === 'section' && (
+        block.text?.text?.includes('Other Commits') || 
+        block.text?.text?.includes('abc1234')
+      )
+    );
+    
+    // Should have at least 2 blocks: one with header, one with the commit
+    expect(commitBlocks.length).toBeGreaterThanOrEqual(1);
+    
+    // Verify that the header "*Other Commits*" is present in at least one block
+    const combinedText = commitBlocks.map((block: any) => block.text.text).join('');
+    expect(combinedText).toContain('*Other Commits*');
+    
+    // Verify that the commit is also present
+    expect(combinedText).toContain('abc1234');
+    
+    // Verify that each block doesn't exceed 3000 characters
+    commitBlocks.forEach((block: any) => {
+      expect(block.text.text.length).toBeLessThanOrEqual(3000);
+    });
+  });
 });

--- a/jira-release-notes-slack/src/generate.test.ts
+++ b/jira-release-notes-slack/src/generate.test.ts
@@ -279,6 +279,84 @@ describe('generate', () => {
     expect(combinedText).toContain('a0000099'); // Last commit
   });
 
+  it('handles newline at exactly maxLength boundary correctly', async () => {
+    // Create text where a newline exists at exactly position 3000
+    // This tests the edge case where lastIndexOf would find a newline at maxLength
+    const prefix = '*:book: Story*\n\n• <https://support.example.com/browse/CC-99999|CC-99999> ';
+    const filler = 'A'.repeat(3000 - prefix.length - 1); // Fill up to position 2999
+    const newlineAtMaxLength = '\n'; // This will be at position 3000
+    const suffix = '\t*Test User*\t*Test User*';
+    const longSummary = filler + newlineAtMaxLength + suffix;
+    
+    const issues = [{
+      "key": "CC-99999",
+      "fields": {
+        "assignee": { "emailAddress": "test@example.com", "displayName": "Test User" },
+        "reporter": { "emailAddress": "test@example.com", "displayName": "Test User" },
+        "issuetype": { "name": "Story", "markdownEmoji": ":book:" },
+        "summary": longSummary
+      },
+      "htmlUrl": "https://support.example.com/browse/CC-99999"
+    }];
+    
+    const result = await generate({
+      title: 'Test',
+      issues: issues,
+      otherCommits: [],
+      slackToken: '',
+      repoUrl: 'https://github.com/myorg/myrepo',
+    });
+
+    const sectionBlocks = result.blocks.filter((block: any) => 
+      block.type === 'section' && 
+      !block.text?.text?.includes('No Jira changes found')
+    );
+    
+    // Verify that each block doesn't exceed 3000 characters
+    sectionBlocks.forEach((block: any) => {
+      expect(block.text.text.length).toBeLessThanOrEqual(3000);
+    });
+  });
+
+  it('handles space at exactly maxLength boundary correctly', async () => {
+    // Create text where a space exists at exactly position 3000
+    // This tests the edge case where lastIndexOf would find a space at maxLength
+    const prefix = '*:book: Story*\n\n• <https://support.example.com/browse/CC-99999|CC-99999> ';
+    const filler = 'A'.repeat(3000 - prefix.length - 1); // Fill up to position 2999
+    const spaceAtMaxLength = ' '; // This will be at position 3000
+    const suffix = 'More text that continues after the space\t*Test User*\t*Test User*';
+    const longSummary = filler + spaceAtMaxLength + suffix;
+    
+    const issues = [{
+      "key": "CC-99999",
+      "fields": {
+        "assignee": { "emailAddress": "test@example.com", "displayName": "Test User" },
+        "reporter": { "emailAddress": "test@example.com", "displayName": "Test User" },
+        "issuetype": { "name": "Story", "markdownEmoji": ":book:" },
+        "summary": longSummary
+      },
+      "htmlUrl": "https://support.example.com/browse/CC-99999"
+    }];
+    
+    const result = await generate({
+      title: 'Test',
+      issues: issues,
+      otherCommits: [],
+      slackToken: '',
+      repoUrl: 'https://github.com/myorg/myrepo',
+    });
+
+    const sectionBlocks = result.blocks.filter((block: any) => 
+      block.type === 'section' && 
+      !block.text?.text?.includes('No Jira changes found')
+    );
+    
+    // Verify that each block doesn't exceed 3000 characters
+    sectionBlocks.forEach((block: any) => {
+      expect(block.text.text.length).toBeLessThanOrEqual(3000);
+    });
+  });
+
   it('truncates blocks when exceeding 50 block limit', async () => {
     // Create enough issues to exceed 50 blocks
     // Each issue creates at least 1 block, so 60 issues should create more than 50 blocks

--- a/jira-release-notes-slack/src/generate.ts
+++ b/jira-release-notes-slack/src/generate.ts
@@ -1,6 +1,65 @@
 import fetch from 'node-fetch';
 import * as core from "@actions/core";
 
+// Slack's maximum text length for a single text block
+const SLACK_MAX_TEXT_LENGTH = 3000;
+
+/**
+ * Splits text into multiple chunks that fit within Slack's character limit.
+ * Attempts to split at word boundaries when possible.
+ */
+function splitTextIntoBlocks(text: string, maxLength: number = SLACK_MAX_TEXT_LENGTH): string[] {
+  if (text.length <= maxLength) {
+    return [text];
+  }
+
+  const blocks: string[] = [];
+  let remaining = text;
+
+  while (remaining.length > maxLength) {
+    // Try to find a good split point (newline or space) near the limit
+    let splitPoint = maxLength;
+    
+    // Look backwards for a newline first (preferred split point)
+    const newlineIndex = remaining.lastIndexOf('\n', maxLength);
+    if (newlineIndex > maxLength * 0.7) { // Only use if it's not too early
+      splitPoint = newlineIndex + 1; // Include the newline
+    } else {
+      // Look backwards for a space
+      const spaceIndex = remaining.lastIndexOf(' ', maxLength);
+      if (spaceIndex > maxLength * 0.7) { // Only use if it's not too early
+        splitPoint = spaceIndex + 1; // Include the space
+      }
+    }
+
+    blocks.push(remaining.substring(0, splitPoint));
+    remaining = remaining.substring(splitPoint);
+  }
+
+  // Add the remaining text
+  if (remaining.length > 0) {
+    blocks.push(remaining);
+  }
+
+  return blocks;
+}
+
+/**
+ * Adds section blocks to the message, automatically splitting text that exceeds the limit.
+ */
+function addSectionBlocks(message: any, text: string): void {
+  const textBlocks = splitTextIntoBlocks(text);
+  for (const blockText of textBlocks) {
+    message.blocks.push({
+      type: 'section',
+      text: {
+        type: 'mrkdwn',
+        text: blockText,
+      },
+    });
+  }
+}
+
 async function getSlackUserId({ email, token }: { email: string, token: string }) {
   const response = await fetch(`https://slack.com/api/users.lookupByEmail?&email=${email}`, {
     method: 'GET',
@@ -80,38 +139,49 @@ export async function generate(
     const jiraKey = `<${issue.htmlUrl}|${issue.key}>`;
     const reporter = issue.fields.reporter?.emailAddress ? emailsToUser[issue.fields.reporter.emailAddress] : '_No Reporter_';
     const assignee = issue.fields.assignee?.emailAddress ? emailsToUser[issue.fields.assignee.emailAddress] : '_Unassigned_';
-    slackMessage.blocks.push(
-      {
-        type: 'section',
-        text: {
-          type: 'mrkdwn',
-          text: `${blockPrefix}• ${jiraKey} ${summary}\n\t${reporter}\t${assignee}`,
-        }
-      },
-    );
+    
+    // Build the text content and add blocks (automatically splits if needed)
+    const fullText = `${blockPrefix}• ${jiraKey} ${summary}\n\t${reporter}\t${assignee}`;
+    addSectionBlocks(slackMessage, fullText);
   }
 
   if (issues.length === 0) {
     core.warning('No Jira changes found');
-    slackMessage.blocks.push({
-      type: 'section',
-      text: {
-        type: 'mrkdwn',
-        text: '_No Jira changes found_'
-      }
-    });
+    addSectionBlocks(slackMessage, '_No Jira changes found_');
   }
 
   if (otherCommits.length > 0) {
     const commitUrl = `${repoUrl}/commit`;
     const commitBullets = otherCommits.map((it) => `• <${commitUrl}/${it.shortHash}|${it.shortHash}> ${it.message}`);
-    slackMessage.blocks.push({
-      type: "section",
-      text: {
-        type: "mrkdwn",
-        text: ['*Other Commits*', ...commitBullets].join('\n'),
-      },
-    });
+    const header = '*Other Commits*';
+    
+    // Split commits into multiple blocks if they exceed Slack's text limit
+    const blocks: string[] = [];
+    let currentBlockText = header;
+    
+    for (const bullet of commitBullets) {
+      const testText = `${currentBlockText}\n${bullet}`;
+      
+      if (testText.length > SLACK_MAX_TEXT_LENGTH) {
+        // Current block is full, save it and start a new one
+        if (currentBlockText !== header) {
+          blocks.push(currentBlockText);
+        }
+        currentBlockText = bullet;
+      } else {
+        currentBlockText = testText;
+      }
+    }
+    
+    // Add the last block if it has content
+    if (currentBlockText) {
+      blocks.push(currentBlockText);
+    }
+    
+    // Add all blocks (automatically splits if needed)
+    for (const blockText of blocks) {
+      addSectionBlocks(slackMessage, blockText);
+    }
   }
 
   if (slackMessage.blocks.length > 50) {

--- a/jira-release-notes-slack/src/generate.ts
+++ b/jira-release-notes-slack/src/generate.ts
@@ -21,12 +21,14 @@ function splitTextIntoBlocks(text: string, maxLength: number = SLACK_MAX_TEXT_LE
     let splitPoint = maxLength;
     
     // Look backwards for a newline first (preferred split point)
-    const newlineIndex = remaining.lastIndexOf('\n', maxLength);
+    // Search up to maxLength - 1 to ensure splitPoint + 1 doesn't exceed maxLength
+    const newlineIndex = remaining.lastIndexOf('\n', maxLength - 1);
     if (newlineIndex > maxLength * 0.7) { // Only use if it's not too early
       splitPoint = newlineIndex + 1; // Include the newline
     } else {
       // Look backwards for a space
-      const spaceIndex = remaining.lastIndexOf(' ', maxLength);
+      // Search up to maxLength - 1 to ensure splitPoint + 1 doesn't exceed maxLength
+      const spaceIndex = remaining.lastIndexOf(' ', maxLength - 1);
       if (spaceIndex > maxLength * 0.7) { // Only use if it's not too early
         splitPoint = spaceIndex + 1; // Include the space
       }

--- a/jira-release-notes-slack/src/generate.ts
+++ b/jira-release-notes-slack/src/generate.ts
@@ -166,7 +166,8 @@ export async function generate(
       
       if (testText.length > SLACK_MAX_TEXT_LENGTH) {
         // Current block is full, save it and start a new one
-        if (currentBlockText !== header) {
+        // Always push currentBlockText if it has content (including header)
+        if (currentBlockText) {
           blocks.push(currentBlockText);
         }
         currentBlockText = bullet;


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: changes are isolated to Slack message formatting to respect Slack’s per-block text limit, with added tests covering long text and boundary cases.
> 
> **Overview**
> Prevents Slack release-note posts from failing due to oversized `section` text by introducing `SLACK_MAX_TEXT_LENGTH` and splitting long text into multiple Slack blocks (preferring newline/space boundaries).
> 
> `generate()` now uses `addSectionBlocks()` for Jira issue lines and the “Other Commits” section, chunking commit bullets across multiple blocks as needed while keeping the existing 50-block truncation behavior. Comprehensive tests were added to validate splitting, edge boundaries, and truncation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 714c1a385a7681bc86ba8d323d6c4fad2f5db744. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->