### PR TITLE
Cc 45210 api docs compare

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Re-usable GitHub Actions
 
 ### Composite Actions
 
+- api-docs-compliance
 - build-java
 - cleanup-java
 - deploy-java

--- a/api-docs-compliance/README.md
+++ b/api-docs-compliance/README.md
@@ -1,0 +1,45 @@
+# API Documentation Compliance Action
+
+This GitHub Action enforces API documentation compliance by running an OpenAPI spec bugbot on pull requests. It checks for violations using rules from a shared `api-documentation` repository and posts review comments that must be resolved before merging.
+
+## Features
+- Checks OpenAPI spec compliance on pull requests.
+- Posts review comments for violations, blocking merge until resolved (when branch protection is enabled).
+- Supports both public and private `api-documentation` repositories.
+- Integrates with Cursor API for bugbot analysis.
+
+## Inputs
+| Name                | Description                                                                 | Required | Default                |
+|---------------------|-----------------------------------------------------------------------------|----------|------------------------|
+| `PERSONAL_ACCESS_TOKEN` | GitHub token with access to the `api-documentation` repo (if private)         | Yes      |                        |
+| `CURSOR_API_KEY`    | Cursor API key for bugbot analysis                                            | Yes      |                        |
+| `API_DOCUMENTATION_REPO` | (Optional) Override for the api-documentation repo (e.g. org/repo)           | No       | cartoncloud/api-documentation |
+
+## Usage
+```yaml
+name: API Documentation Compliance
+on:
+  pull_request:
+    branches:
+      - '**'
+      - '!release/production'
+      - '!production'
+
+jobs:
+  api-docs-compliance:
+    uses: ./api-docs-compliance  # or org/repo/path@ref if published
+    secrets:
+      PERSONAL_ACCESS_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+      CURSOR_API_KEY: ${{ secrets.CURSOR_API_KEY }}
+    with:
+      API_DOCUMENTATION_REPO: cartoncloud/api-documentation  # optional
+```
+
+## Branch Protection
+To block merges until all bugbot comments are resolved:
+1. Go to **Settings → Branches → Branch protection** for your branch.
+2. Enable **Require conversation resolution before merging**.
+
+## License
+MIT
+

--- a/api-docs-compliance/action.yml
+++ b/api-docs-compliance/action.yml
@@ -87,6 +87,7 @@ runs:
         MODEL: kimi-k2.5
       run: |
         set -e
-        export PATH="$CURSOR_BIN:$PATH"
+        export PATH="${CURSOR_BIN:-$HOME/.cursor/bin}:$PATH"
         PROMPT=$(cat .github/rules/api-spec-openapi-bugbot.prompt)
-        agent -p "$PROMPT" --model "$MODEL" --output-format=text
+        agent -p "$PROMPT" --model "$MODEL" --output-format=text || true
+        # Do not fail the job on agent exit code: violations are surfaced via the resolvable review thread (RULE.mdc), not job failure.

--- a/api-docs-compliance/action.yml
+++ b/api-docs-compliance/action.yml
@@ -70,51 +70,23 @@ runs:
         mkdir -p .github/rules
         cp api-documentation/.cursor/rules/api-spec-rules/RULE.mdc .github/rules/api-spec-openapi-bugbot.prompt
 
-    # Pinned to release tag (not @main) to avoid supply chain risk: action runs with CURSOR_API_KEY and PAT
-    - name: Run OpenAPI spec bugbot (Cursor)
-      id: bugbot
-      uses: erans/autoagent-action@v1.1.0
-      env:
-        CURSOR_API_KEY: ${{ inputs.CURSOR_API_KEY }}
-        GITHUB_TOKEN: ${{ inputs.PERSONAL_ACCESS_TOKEN }}
-        GH_TOKEN: ${{ inputs.PERSONAL_ACCESS_TOKEN }}
-        MODEL: kimi-k2.5
-      with:
-        agent: cursor
-        action: comment
-        scope: changed
-        install-agent: true
-        customFiles: |
-          - .github/rules/api-spec-openapi-bugbot.prompt
+    - name: Install Cursor CLI
+      shell: bash
+      run: |
+        curl https://cursor.com/install -fsS | bash
+        echo "$HOME/.cursor/bin" >> $GITHUB_PATH
+        echo "CURSOR_BIN=$HOME/.cursor/bin" >> $GITHUB_ENV
 
-    - name: Create resolvable review thread only when violations found
+    - name: Run OpenAPI spec bugbot (Cursor CLI)
+      id: bugbot
       shell: bash
       env:
+        CURSOR_API_KEY: ${{ inputs.CURSOR_API_KEY }}
         GH_TOKEN: ${{ inputs.PERSONAL_ACCESS_TOKEN }}
-        PR_NUM: ${{ github.event.pull_request.number }}
+        GITHUB_REPOSITORY: ${{ github.repository }}
+        MODEL: kimi-k2.5
       run: |
         set -e
-        # Bugbot posts with PAT (e.g. cartoncloud-robot) when GITHUB_TOKEN/GH_TOKEN are overridden, so match by content not by user
-        BODY=$(gh api repos/${{ github.repository }}/issues/$PR_NUM/comments --paginate --jq '[.[] | select(.body | test("COMPLIANT_NO_VIOLATIONS"))] | .[-1].body // empty' 2>/dev/null || true)
-        if [ -n "$BODY" ]; then
-          echo "API spec check passed (COMPLIANT_NO_VIOLATIONS). No review thread created; merge does not require resolving a conversation."
-          exit 0
-        fi
-        # Only create a blocking review when the bugbot actually posted a violation comment. If it posted nothing (no API spec files in scope or autoagent failed), do not block.
-        HAS_VIOLATION_COMMENT=$(gh api repos/${{ github.repository }}/issues/$PR_NUM/comments --paginate --jq '[.[] | select((.body | test("COMPLIANT_NO_VIOLATIONS")) | not) | select(.body | test("API spec bugbot|API spec review|api-spec-openapi-bugbot|API Documentation Compliance"))] | length' 2>/dev/null || echo "0")
-        if [ "${HAS_VIOLATION_COMMENT:-0}" -eq 0 ]; then
-          echo "No bugbot violation comment found (no API spec files in scope or bugbot did not post). Skipping review thread; merge not blocked."
-          exit 0
-        fi
-        FIRST_FILE=$(gh pr diff "$PR_NUM" --name-only 2>/dev/null | head -n1 || true)
-        if [ -z "$FIRST_FILE" ]; then
-          echo "No changed files; skipping review thread."
-          exit 0
-        fi
-        COMMENT_BODY="**API spec bugbot** (.cursor/rules/api-spec-rules/RULE.mdc from api-documentation) found issues. Resolve this conversation when all findings from the bugbot comment above are addressed."
-        jq -n \
-          --arg path "$FIRST_FILE" \
-          --arg body "$COMMENT_BODY" \
-          '{event: "COMMENT", body: "API spec review. See the review comment below.", comments: [{path: $path, line: 1, body: $body}]}' > /tmp/review.json
-        gh api repos/${{ github.repository }}/pulls/$PR_NUM/reviews --method POST --input /tmp/review.json
-        echo "Review comment created (resolve this conversation before merge when branch protection is enabled)."
+        export PATH="$CURSOR_BIN:$PATH"
+        PROMPT=$(cat .github/rules/api-spec-openapi-bugbot.prompt)
+        agent -p "$PROMPT" --model "$MODEL" --output-format=text

--- a/api-docs-compliance/action.yml
+++ b/api-docs-compliance/action.yml
@@ -37,13 +37,25 @@ runs:
           fi
         fi
 
-    - name: Checkout api-documentation
-      uses: actions/checkout@v4
-      with:
-        repository: ${{ inputs.API_DOCUMENTATION_REPO }}
-        ref: ${{ inputs.API_DOCUMENTATION_BRANCH }}
-        path: api-documentation
-        token: ${{ inputs.PERSONAL_ACCESS_TOKEN }}
+    - name: Checkout api-documentation (with branch fallback)
+      shell: bash
+      run: |
+        set -e
+        REPO="${{ inputs.API_DOCUMENTATION_REPO }}"
+        BRANCH="${{ inputs.API_DOCUMENTATION_BRANCH }}"
+        TOKEN="${{ inputs.PERSONAL_ACCESS_TOKEN }}"
+        TARGET_DIR="api-documentation"
+        rm -rf "$TARGET_DIR"
+        if [ "$BRANCH" = "main" ]; then
+          git clone --depth 1 --branch "$BRANCH" "https://x-access-token:$TOKEN@github.com/$REPO.git" "$TARGET_DIR"
+        else
+          if git clone --depth 1 --branch "$BRANCH" "https://x-access-token:$TOKEN@github.com/$REPO.git" "$TARGET_DIR"; then
+            echo "Checked out branch $BRANCH."
+          else
+            echo "Branch $BRANCH not found, falling back to main."
+            git clone --depth 1 --branch main "https://x-access-token:$TOKEN@github.com/$REPO.git" "$TARGET_DIR"
+          fi
+        fi
 
     - name: Clear previous API spec bugbot comments
       uses: aki77/delete-pr-comments-action@v3

--- a/api-docs-compliance/action.yml
+++ b/api-docs-compliance/action.yml
@@ -84,12 +84,25 @@ runs:
         CURSOR_API_KEY: ${{ inputs.CURSOR_API_KEY }}
         GH_TOKEN: ${{ inputs.PERSONAL_ACCESS_TOKEN }}
         GITHUB_REPOSITORY: ${{ github.repository }}
+        PR_NUM: ${{ github.event.pull_request.number }}
         MODEL: kimi-k2.5
       run: |
         set -e
         export PATH="${CURSOR_BIN:-$HOME/.cursor/bin}:$PATH"
-        PROMPT=$(cat .github/rules/api-spec-openapi-bugbot.prompt)
-        agent -p "$PROMPT" --model "$MODEL" --output-format=text > /tmp/bugbot-output.txt 2>&1 || true
+        RULE_PROMPT=$(cat .github/rules/api-spec-openapi-bugbot.prompt)
+        CHANGED_FILES=$(gh pr diff "$PR_NUM" --name-only 2>/dev/null | head -100 || true)
+        OPENAPI_SPEC="openapi/index.yml"
+        [ -d api-documentation/openapi ] && OPENAPI_SPEC="api-documentation/openapi/index.yml"
+        PROMPT="${RULE_PROMPT}
+
+        ---
+        Context for this run:
+        - OpenAPI contract (canonical): ${OPENAPI_SPEC}
+        - Files changed in this PR (review only these):
+        ${CHANGED_FILES}
+
+        Output your full review to stdout. If no violations, output exactly COMPLIANT_NO_VIOLATIONS first."
+        agent --print --output-format=text --model "$MODEL" --trust --workspace "$GITHUB_WORKSPACE" -- "$PROMPT" > /tmp/bugbot-output.txt 2>&1 || true
 
     - name: Create resolvable review thread when violations found
       shell: bash
@@ -103,7 +116,14 @@ runs:
           exit 0
         fi
         if [ ! -s /tmp/bugbot-output.txt ]; then
-          echo "Bugbot produced no output; skipping review."
+          echo "Bugbot produced no output; posting review to request re-run or log check."
+          FIRST_FILE=$(gh pr diff "$PR_NUM" --name-only 2>/dev/null | head -n1 || echo "README.md")
+          BODY="**API spec review (API Documentation Compliance).** Bugbot produced no output. This may indicate agent timeout, no matching changed files, or a CLI error. Please check the workflow logs for the 'Run OpenAPI spec bugbot' step and re-run the workflow if needed."
+          jq -n \
+            --arg path "$FIRST_FILE" \
+            --arg body "$BODY" \
+            '{event: "COMMENT", body: "API spec review. See the review comment below.", comments: [{path: $path, line: 1, body: $body}]}' > /tmp/review.json
+          gh api repos/${{ github.repository }}/pulls/$PR_NUM/reviews --method POST --input /tmp/review.json
           exit 0
         fi
         FIRST_FILE=$(gh pr diff "$PR_NUM" --name-only 2>/dev/null | head -n1 || echo "README.md")

--- a/api-docs-compliance/action.yml
+++ b/api-docs-compliance/action.yml
@@ -100,8 +100,9 @@ runs:
         PR_NUM: ${{ github.event.pull_request.number }}
       run: |
         set -e
-        BODY=$(gh api repos/${{ github.repository }}/issues/$PR_NUM/comments --jq 'reverse | map(select(.user.login == "github-actions[bot]")) | .[0].body // empty' 2>/dev/null || true)
-        if echo "$BODY" | grep -q 'COMPLIANT_NO_VIOLATIONS'; then
+        # Bugbot posts with PAT (e.g. cartoncloud-robot) when GITHUB_TOKEN/GH_TOKEN are overridden, so match by content not by user
+        BODY=$(gh api repos/${{ github.repository }}/issues/$PR_NUM/comments --jq 'reverse | map(select(.body | test("COMPLIANT_NO_VIOLATIONS"))) | .[0].body // empty' 2>/dev/null || true)
+        if [ -n "$BODY" ]; then
           echo "API spec check passed (COMPLIANT_NO_VIOLATIONS). No review thread created; merge does not require resolving a conversation."
           exit 0
         fi

--- a/api-docs-compliance/action.yml
+++ b/api-docs-compliance/action.yml
@@ -118,7 +118,8 @@ runs:
         fi
         if [ ! -s /tmp/bugbot-output.txt ]; then
           echo "Bugbot produced no output; posting review to request re-run or log check."
-          FIRST_FILE=$(gh pr diff "$PR_NUM" --name-only 2>/dev/null | head -n1 || echo "README.md")
+          FIRST_FILE=$(gh pr diff "$PR_NUM" --name-only 2>/dev/null | head -n1)
+          FIRST_FILE=${FIRST_FILE:-README.md}
           BODY="**API spec review (API Documentation Compliance).** Bugbot produced no output. This may indicate agent timeout, no matching changed files, or a CLI error. Please check the workflow logs for the 'Run OpenAPI spec bugbot' step and re-run the workflow if needed."
           jq -n \
             --arg path "$FIRST_FILE" \
@@ -127,7 +128,8 @@ runs:
           gh api repos/${{ github.repository }}/pulls/$PR_NUM/reviews --method POST --input /tmp/review.json
           exit 0
         fi
-        FIRST_FILE=$(gh pr diff "$PR_NUM" --name-only 2>/dev/null | head -n1 || echo "README.md")
+        FIRST_FILE=$(gh pr diff "$PR_NUM" --name-only 2>/dev/null | head -n1)
+        FIRST_FILE=${FIRST_FILE:-README.md}
         PREFIX="**API spec review (API Documentation Compliance).** Resolve this conversation when all findings below are addressed.
 
         "

--- a/api-docs-compliance/action.yml
+++ b/api-docs-compliance/action.yml
@@ -1,0 +1,111 @@
+name: 'API Documentation Compliance'
+description: 'Checks OpenAPI spec compliance on PRs using shared api-documentation rules.'
+inputs:
+  PERSONAL_ACCESS_TOKEN:
+    description: 'GitHub token with access to the api-documentation repo (if private)'
+    required: true
+  CURSOR_API_KEY:
+    description: 'Cursor API key for bugbot analysis'
+    required: true
+  API_DOCUMENTATION_REPO:
+    description: 'Override for the api-documentation repo (e.g. org/repo)'
+    required: false
+    default: cartoncloud/api-documentation
+  API_DOCUMENTATION_BRANCH:
+    description: 'Branch to use for the api-documentation repo (default: main)'
+    required: false
+    default: main
+runs:
+  using: composite
+  steps:
+    - name: Checkout target repository
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+
+    - name: Require api-documentation token for private repo access
+      shell: bash
+      run: |
+        API_DOC_REPO="${{ inputs.API_DOCUMENTATION_REPO }}"
+        CURRENT_REPO="${{ github.repository }}"
+        if [ "$API_DOC_REPO" = "$CURRENT_REPO" ]; then
+          echo "Api-documentation repo is the current repo; GITHUB_TOKEN will be used."
+        else
+          if [ -z "${{ inputs.PERSONAL_ACCESS_TOKEN }}" ]; then
+            echo "::error::Checking out the private api-documentation repo ($API_DOC_REPO) requires PERSONAL_ACCESS_TOKEN."
+            exit 1
+          fi
+        fi
+
+    - name: Checkout api-documentation
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ inputs.API_DOCUMENTATION_REPO }}
+        ref: ${{ inputs.API_DOCUMENTATION_BRANCH }}
+        path: api-documentation
+        token: ${{ inputs.PERSONAL_ACCESS_TOKEN }}
+
+    - name: Clear previous API spec bugbot comments
+      uses: aki77/delete-pr-comments-action@v3
+      with:
+        token: ${{ inputs.PERSONAL_ACCESS_TOKEN }}
+        pullRequestNumber: ${{ github.event.pull_request.number }}
+        includeIssueComments: 'true'
+        includeOverallReviewComments: 'true'
+        usernames: |-
+          cartoncloud-robot
+          github-actions[bot]
+
+    - name: Prepare API spec bugbot rules
+      shell: bash
+      run: |
+        mkdir -p .github/rules
+        cp api-documentation/.cursor/rules/api-spec-rules/RULE.mdc .github/rules/api-spec-openapi-bugbot.prompt
+
+    - name: Require Cursor API key for bugbot
+      shell: bash
+      run: |
+        if [ -z "${{ inputs.CURSOR_API_KEY }}" ]; then
+          echo "::error::OpenAPI spec bugbot requires CURSOR_API_KEY (secret)."
+          exit 1
+        fi
+
+    - name: Run OpenAPI spec bugbot (Cursor)
+      id: bugbot
+      uses: erans/autoagent-action@main
+      env:
+        CURSOR_API_KEY: ${{ inputs.CURSOR_API_KEY }}
+        GITHUB_TOKEN: ${{ inputs.PERSONAL_ACCESS_TOKEN }}
+        GH_TOKEN: ${{ inputs.PERSONAL_ACCESS_TOKEN }}
+      with:
+        agent: cursor
+        action: comment
+        scope: changed
+        install-agent: true
+        customFiles: |
+          - .github/rules/api-spec-openapi-bugbot.prompt
+
+    - name: Create resolvable review thread only when violations found
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.PERSONAL_ACCESS_TOKEN }}
+        PR_NUM: ${{ github.event.pull_request.number }}
+      run: |
+        set -e
+        BODY=$(gh api repos/${{ github.repository }}/issues/$PR_NUM/comments --jq 'reverse | map(select(.user.login == "github-actions[bot]")) | .[0].body // empty' 2>/dev/null || true)
+        if echo "$BODY" | grep -q 'COMPLIANT_NO_VIOLATIONS'; then
+          echo "API spec check passed (COMPLIANT_NO_VIOLATIONS). No review thread created; merge does not require resolving a conversation."
+          exit 0
+        fi
+        FIRST_FILE=$(gh pr diff "$PR_NUM" --name-only 2>/dev/null | head -n1 || true)
+        if [ -z "$FIRST_FILE" ]; then
+          echo "No changed files; skipping review thread."
+          exit 0
+        fi
+        COMMENT_BODY="**API spec bugbot** (.cursor/rules/api-spec-rules/RULE.mdc from api-documentation) found issues. Resolve this conversation when all findings from the bugbot comment above are addressed."
+        jq -n \
+          --arg path "$FIRST_FILE" \
+          --arg body "$COMMENT_BODY" \
+          '{event: "COMMENT", body: "API spec review. See the review comment below.", comments: [{path: $path, line: 1, body: $body}]}' > /tmp/review.json
+        gh api repos/${{ github.repository }}/pulls/$PR_NUM/reviews --input /tmp/review.json
+        echo "Review comment created (resolve this conversation before merge when branch protection is enabled)."

--- a/api-docs-compliance/action.yml
+++ b/api-docs-compliance/action.yml
@@ -19,7 +19,7 @@ runs:
   using: composite
   steps:
     - name: Checkout target repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         fetch-depth: 0
 
@@ -103,13 +103,13 @@ runs:
       run: |
         set -e
         # Bugbot posts with PAT (e.g. cartoncloud-robot) when GITHUB_TOKEN/GH_TOKEN are overridden, so match by content not by user
-        BODY=$(gh api repos/${{ github.repository }}/issues/$PR_NUM/comments --jq 'reverse | map(select(.body | test("COMPLIANT_NO_VIOLATIONS"))) | .[0].body // empty' 2>/dev/null || true)
+        BODY=$(gh api repos/${{ github.repository }}/issues/$PR_NUM/comments --paginate --jq '[.[] | select(.body | test("COMPLIANT_NO_VIOLATIONS"))] | .[-1].body // empty' 2>/dev/null || true)
         if [ -n "$BODY" ]; then
           echo "API spec check passed (COMPLIANT_NO_VIOLATIONS). No review thread created; merge does not require resolving a conversation."
           exit 0
         fi
         # Only create a blocking review when the bugbot actually posted a violation comment. If it posted nothing (no API spec files in scope or autoagent failed), do not block.
-        HAS_VIOLATION_COMMENT=$(gh api repos/${{ github.repository }}/issues/$PR_NUM/comments --jq 'reverse | map(select((.body | test("COMPLIANT_NO_VIOLATIONS")) | not)) | map(select(.body | test("API spec bugbot|API spec review|api-spec-openapi-bugbot|API Documentation Compliance"))) | length' 2>/dev/null || echo "0")
+        HAS_VIOLATION_COMMENT=$(gh api repos/${{ github.repository }}/issues/$PR_NUM/comments --paginate --jq '[.[] | select((.body | test("COMPLIANT_NO_VIOLATIONS")) | not) | select(.body | test("API spec bugbot|API spec review|api-spec-openapi-bugbot|API Documentation Compliance"))] | length' 2>/dev/null || echo "0")
         if [ "${HAS_VIOLATION_COMMENT:-0}" -eq 0 ]; then
           echo "No bugbot violation comment found (no API spec files in scope or bugbot did not post). Skipping review thread; merge not blocked."
           exit 0

--- a/api-docs-compliance/action.yml
+++ b/api-docs-compliance/action.yml
@@ -25,11 +25,15 @@ runs:
 
     - name: Checkout api-documentation (with branch fallback)
       shell: bash
+      env:
+        API_DOCUMENTATION_REPO: ${{ inputs.API_DOCUMENTATION_REPO }}
+        API_DOCUMENTATION_BRANCH: ${{ inputs.API_DOCUMENTATION_BRANCH }}
+        PERSONAL_ACCESS_TOKEN: ${{ inputs.PERSONAL_ACCESS_TOKEN }}
       run: |
         set -e
-        REPO="${{ inputs.API_DOCUMENTATION_REPO }}"
-        BRANCH="${{ inputs.API_DOCUMENTATION_BRANCH }}"
-        TOKEN="${{ inputs.PERSONAL_ACCESS_TOKEN }}"
+        REPO="$API_DOCUMENTATION_REPO"
+        BRANCH="$API_DOCUMENTATION_BRANCH"
+        TOKEN="$PERSONAL_ACCESS_TOKEN"
         TARGET_DIR="api-documentation"
         rm -rf "$TARGET_DIR"
         if [ "$BRANCH" = "main" ]; then
@@ -59,14 +63,6 @@ runs:
       run: |
         mkdir -p .github/rules
         cp api-documentation/.cursor/rules/api-spec-rules/RULE.mdc .github/rules/api-spec-openapi-bugbot.prompt
-
-    - name: Require Cursor API key for bugbot
-      shell: bash
-      run: |
-        if [ -z "${{ inputs.CURSOR_API_KEY }}" ]; then
-          echo "::error::OpenAPI spec bugbot requires CURSOR_API_KEY (secret)."
-          exit 1
-        fi
 
     - name: Run OpenAPI spec bugbot (Cursor)
       id: bugbot

--- a/api-docs-compliance/action.yml
+++ b/api-docs-compliance/action.yml
@@ -89,5 +89,31 @@ runs:
         set -e
         export PATH="${CURSOR_BIN:-$HOME/.cursor/bin}:$PATH"
         PROMPT=$(cat .github/rules/api-spec-openapi-bugbot.prompt)
-        agent -p "$PROMPT" --model "$MODEL" --output-format=text || true
-        # Do not fail the job on agent exit code: violations are surfaced via the resolvable review thread (RULE.mdc), not job failure.
+        agent -p "$PROMPT" --model "$MODEL" --output-format=text > /tmp/bugbot-output.txt 2>&1 || true
+
+    - name: Create resolvable review thread when violations found
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.PERSONAL_ACCESS_TOKEN }}
+        PR_NUM: ${{ github.event.pull_request.number }}
+      run: |
+        set -e
+        if grep -q "COMPLIANT_NO_VIOLATIONS" /tmp/bugbot-output.txt 2>/dev/null; then
+          echo "API spec check passed (COMPLIANT_NO_VIOLATIONS). No review thread created."
+          exit 0
+        fi
+        if [ ! -s /tmp/bugbot-output.txt ]; then
+          echo "Bugbot produced no output; skipping review."
+          exit 0
+        fi
+        FIRST_FILE=$(gh pr diff "$PR_NUM" --name-only 2>/dev/null | head -n1 || echo "README.md")
+        PREFIX="**API spec review (API Documentation Compliance).** Resolve this conversation when all findings below are addressed.
+
+        "
+        jq -n \
+          --arg path "$FIRST_FILE" \
+          --rawfile report /tmp/bugbot-output.txt \
+          --arg prefix "$PREFIX" \
+          '{event: "COMMENT", body: "API spec review. See the review comment below.", comments: [{path: $path, line: 1, body: ($prefix + $report)}]}' > /tmp/review.json
+        gh api repos/${{ github.repository }}/pulls/$PR_NUM/reviews --method POST --input /tmp/review.json
+        echo "Review comment created (resolve this conversation before merge when branch protection is enabled)."

--- a/api-docs-compliance/action.yml
+++ b/api-docs-compliance/action.yml
@@ -78,9 +78,10 @@ runs:
         - Do not conclude "no spec mismatch" solely because a path is not in index.yml; definitions and schemas in features/*.yml are part of the contract. Flag renames or removals that break those schemas.
         PROMPT
 
+    # Pinned to release tag (not @main) to avoid supply chain risk: action runs with CURSOR_API_KEY and PAT
     - name: Run OpenAPI spec bugbot (Cursor)
       id: bugbot
-      uses: erans/autoagent-action@main
+      uses: erans/autoagent-action@v1.1.0
       env:
         CURSOR_API_KEY: ${{ inputs.CURSOR_API_KEY }}
         GITHUB_TOKEN: ${{ inputs.PERSONAL_ACCESS_TOKEN }}

--- a/api-docs-compliance/action.yml
+++ b/api-docs-compliance/action.yml
@@ -70,7 +70,7 @@ runs:
     - name: Install Cursor CLI
       shell: bash
       run: |
-        curl https://cursor.com/install -fsS | bash
+        curl https://cursor.com/install -fsSL | bash
         echo "$HOME/.cursor/bin" >> $GITHUB_PATH
         echo "CURSOR_BIN=$HOME/.cursor/bin" >> $GITHUB_ENV
 

--- a/api-docs-compliance/action.yml
+++ b/api-docs-compliance/action.yml
@@ -87,6 +87,7 @@ runs:
         CURSOR_API_KEY: ${{ inputs.CURSOR_API_KEY }}
         GITHUB_TOKEN: ${{ inputs.PERSONAL_ACCESS_TOKEN }}
         GH_TOKEN: ${{ inputs.PERSONAL_ACCESS_TOKEN }}
+        MODEL: grok
       with:
         agent: cursor
         action: comment

--- a/api-docs-compliance/action.yml
+++ b/api-docs-compliance/action.yml
@@ -55,11 +55,8 @@ runs:
         includeIssueComments: 'true'
         includeOverallReviewComments: 'true'
         bodyContains: |-
-          API spec bugbot
           API spec review
-          api-spec-openapi-bugbot
           API Documentation Compliance
-          COMPLIANT_NO_VIOLATIONS
         usernames: |-
           cartoncloud-robot
           github-actions[bot]

--- a/api-docs-compliance/action.yml
+++ b/api-docs-compliance/action.yml
@@ -107,6 +107,12 @@ runs:
           echo "API spec check passed (COMPLIANT_NO_VIOLATIONS). No review thread created; merge does not require resolving a conversation."
           exit 0
         fi
+        # Only create a blocking review when the bugbot actually posted a violation comment. If it posted nothing (no API spec files in scope or autoagent failed), do not block.
+        HAS_VIOLATION_COMMENT=$(gh api repos/${{ github.repository }}/issues/$PR_NUM/comments --jq 'reverse | map(select((.body | test("COMPLIANT_NO_VIOLATIONS")) | not)) | map(select(.body | test("API spec bugbot|API spec review|api-spec-openapi-bugbot|API Documentation Compliance"))) | length' 2>/dev/null || echo "0")
+        if [ "${HAS_VIOLATION_COMMENT:-0}" -eq 0 ]; then
+          echo "No bugbot violation comment found (no API spec files in scope or bugbot did not post). Skipping review thread; merge not blocked."
+          exit 0
+        fi
         FIRST_FILE=$(gh pr diff "$PR_NUM" --name-only 2>/dev/null | head -n1 || true)
         if [ -z "$FIRST_FILE" ]; then
           echo "No changed files; skipping review thread."

--- a/api-docs-compliance/action.yml
+++ b/api-docs-compliance/action.yml
@@ -54,6 +54,11 @@ runs:
         pullRequestNumber: ${{ github.event.pull_request.number }}
         includeIssueComments: 'true'
         includeOverallReviewComments: 'true'
+        bodyContains: |-
+          API spec bugbot
+          API spec review
+          api-spec-openapi-bugbot
+          API Documentation Compliance Review
         usernames: |-
           cartoncloud-robot
           github-actions[bot]

--- a/api-docs-compliance/action.yml
+++ b/api-docs-compliance/action.yml
@@ -58,7 +58,7 @@ runs:
           API spec bugbot
           API spec review
           api-spec-openapi-bugbot
-          API Documentation Compliance Review
+          API Documentation Compliance
           COMPLIANT_NO_VIOLATIONS
         usernames: |-
           cartoncloud-robot
@@ -69,15 +69,6 @@ runs:
       run: |
         mkdir -p .github/rules
         cp api-documentation/.cursor/rules/api-spec-rules/RULE.mdc .github/rules/api-spec-openapi-bugbot.prompt
-        # Only PR-changed files are in scope; validate them against the api-documentation contract (full spec)
-        cat >> .github/rules/api-spec-openapi-bugbot.prompt << 'PROMPT'
-
-        ## Scope and contract (mandatory)
-        - Inspect only the files changed in this PR. Do not require other repo files to be in scope.
-        - Validate those changed files against the OpenAPI contract in api-documentation/openapi/. You MUST read that folder (it is in the workspace): api-documentation/openapi/index.yml and all referenced specs under api-documentation/openapi/features/ (e.g. documents.yml).
-        - Document schema (status, access, etc.) is in api-documentation/openapi/features/documents.yml. Compare any changed *-definition-schema.json (or other API-related files) against this contract.
-        - Do not conclude "no spec mismatch" solely because a path is not in index.yml; definitions and schemas in features/*.yml are part of the contract. Flag renames or removals that break those schemas.
-        PROMPT
 
     # Pinned to release tag (not @main) to avoid supply chain risk: action runs with CURSOR_API_KEY and PAT
     - name: Run OpenAPI spec bugbot (Cursor)
@@ -125,5 +116,5 @@ runs:
           --arg path "$FIRST_FILE" \
           --arg body "$COMMENT_BODY" \
           '{event: "COMMENT", body: "API spec review. See the review comment below.", comments: [{path: $path, line: 1, body: $body}]}' > /tmp/review.json
-        gh api repos/${{ github.repository }}/pulls/$PR_NUM/reviews --input /tmp/review.json
+        gh api repos/${{ github.repository }}/pulls/$PR_NUM/reviews --method POST --input /tmp/review.json
         echo "Review comment created (resolve this conversation before merge when branch protection is enabled)."

--- a/api-docs-compliance/action.yml
+++ b/api-docs-compliance/action.yml
@@ -23,20 +23,6 @@ runs:
       with:
         fetch-depth: 0
 
-    - name: Require api-documentation token for private repo access
-      shell: bash
-      run: |
-        API_DOC_REPO="${{ inputs.API_DOCUMENTATION_REPO }}"
-        CURRENT_REPO="${{ github.repository }}"
-        if [ "$API_DOC_REPO" = "$CURRENT_REPO" ]; then
-          echo "Api-documentation repo is the current repo; GITHUB_TOKEN will be used."
-        else
-          if [ -z "${{ inputs.PERSONAL_ACCESS_TOKEN }}" ]; then
-            echo "::error::Checking out the private api-documentation repo ($API_DOC_REPO) requires PERSONAL_ACCESS_TOKEN."
-            exit 1
-          fi
-        fi
-
     - name: Checkout api-documentation (with branch fallback)
       shell: bash
       run: |

--- a/api-docs-compliance/action.yml
+++ b/api-docs-compliance/action.yml
@@ -102,7 +102,8 @@ runs:
         ${CHANGED_FILES}
 
         Output your full review to stdout. If no violations, output exactly COMPLIANT_NO_VIOLATIONS first."
-        agent --print --output-format=text --model "$MODEL" --trust --workspace "$GITHUB_WORKSPACE" -- "$PROMPT" > /tmp/bugbot-output.txt 2>&1 || true
+        agent --print --output-format=text --model "$MODEL" --trust --workspace "$GITHUB_WORKSPACE" -- "$PROMPT" > /tmp/bugbot-output.txt 2>/tmp/bugbot-stderr.txt || true
+        [ -s /tmp/bugbot-stderr.txt ] && cat /tmp/bugbot-stderr.txt >&2 || true
 
     - name: Create resolvable review thread when violations found
       shell: bash
@@ -111,7 +112,7 @@ runs:
         PR_NUM: ${{ github.event.pull_request.number }}
       run: |
         set -e
-        if grep -q "COMPLIANT_NO_VIOLATIONS" /tmp/bugbot-output.txt 2>/dev/null; then
+        if head -n1 /tmp/bugbot-output.txt 2>/dev/null | grep -qFx "COMPLIANT_NO_VIOLATIONS"; then
           echo "API spec check passed (COMPLIANT_NO_VIOLATIONS). No review thread created."
           exit 0
         fi

--- a/api-docs-compliance/action.yml
+++ b/api-docs-compliance/action.yml
@@ -59,6 +59,7 @@ runs:
           API spec review
           api-spec-openapi-bugbot
           API Documentation Compliance Review
+          COMPLIANT_NO_VIOLATIONS
         usernames: |-
           cartoncloud-robot
           github-actions[bot]

--- a/api-docs-compliance/action.yml
+++ b/api-docs-compliance/action.yml
@@ -87,7 +87,7 @@ runs:
         CURSOR_API_KEY: ${{ inputs.CURSOR_API_KEY }}
         GITHUB_TOKEN: ${{ inputs.PERSONAL_ACCESS_TOKEN }}
         GH_TOKEN: ${{ inputs.PERSONAL_ACCESS_TOKEN }}
-        MODEL: grok
+        MODEL: moonshotai/kimi-k2.5
       with:
         agent: cursor
         action: comment

--- a/api-docs-compliance/action.yml
+++ b/api-docs-compliance/action.yml
@@ -87,7 +87,7 @@ runs:
         CURSOR_API_KEY: ${{ inputs.CURSOR_API_KEY }}
         GITHUB_TOKEN: ${{ inputs.PERSONAL_ACCESS_TOKEN }}
         GH_TOKEN: ${{ inputs.PERSONAL_ACCESS_TOKEN }}
-        MODEL: moonshotai/kimi-k2.5
+        MODEL: kimi-k2.5
       with:
         agent: cursor
         action: comment

--- a/api-docs-compliance/action.yml
+++ b/api-docs-compliance/action.yml
@@ -68,6 +68,15 @@ runs:
       run: |
         mkdir -p .github/rules
         cp api-documentation/.cursor/rules/api-spec-rules/RULE.mdc .github/rules/api-spec-openapi-bugbot.prompt
+        # Only PR-changed files are in scope; validate them against the api-documentation contract (full spec)
+        cat >> .github/rules/api-spec-openapi-bugbot.prompt << 'PROMPT'
+
+        ## Scope and contract (mandatory)
+        - Inspect only the files changed in this PR. Do not require other repo files to be in scope.
+        - Validate those changed files against the OpenAPI contract in api-documentation/openapi/. You MUST read that folder (it is in the workspace): api-documentation/openapi/index.yml and all referenced specs under api-documentation/openapi/features/ (e.g. documents.yml).
+        - Document schema (status, access, etc.) is in api-documentation/openapi/features/documents.yml. Compare any changed *-definition-schema.json (or other API-related files) against this contract.
+        - Do not conclude "no spec mismatch" solely because a path is not in index.yml; definitions and schemas in features/*.yml are part of the contract. Flag renames or removals that break those schemas.
+        PROMPT
 
     - name: Run OpenAPI spec bugbot (Cursor)
       id: bugbot


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds a new PR-gating composite action that runs external tooling (git clone + Cursor CLI + `gh api`) and posts/deletes PR review comments using a PAT, so failures or misconfiguration can block merges and has token/permissions implications.
> 
> **Overview**
> Adds a new composite action, `api-docs-compliance`, to enforce OpenAPI documentation compliance on pull requests by pulling rule prompts from a shared `api-documentation` repo and running the Cursor CLI bugbot against the PR diff.
> 
> The workflow clears prior bot comments, supports configurable `API_DOCUMENTATION_REPO`/`API_DOCUMENTATION_BRANCH` with a fallback to `main`, and posts a **resolvable** PR review thread (or a rerun/log message when output is empty) to gate merges via branch protection.
> 
> Updates the root `README.md` to list the new `api-docs-compliance` action.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ed1abf8a4101eec24ed185672f4d90913d65da1a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->