### PR TITLE
CC-45210 convert rule to skill

### DIFF
--- a/api-docs-compliance/action.yml
+++ b/api-docs-compliance/action.yml
@@ -64,11 +64,29 @@ runs:
     - name: Prepare API spec contract review skill and OpenAPI spec
       shell: bash
       run: |
+        set -euo pipefail
+        SKILL_SRC="api-documentation/.cursor/skills/api-spec-contract-review"
+        if [ ! -d "$SKILL_SRC" ]; then
+          echo "::error::Expected skill directory missing: $SKILL_SRC (api-documentation repo may have restructured)." >&2
+          exit 1
+        fi
         mkdir -p .cursor/skills
-        cp -r api-documentation/.cursor/skills/api-spec-contract-review .cursor/skills/
+        cp -r "$SKILL_SRC" .cursor/skills/
         # Merge canonical spec into openapi/ so it ends up at openapi/index.yml even when repo already has openapi/
         mkdir -p openapi
+        if [ ! -d api-documentation/openapi ]; then
+          echo "::error::Expected openapi/ missing under api-documentation clone." >&2
+          exit 1
+        fi
         rsync -a api-documentation/openapi/ openapi/
+        for required in \
+          ".cursor/skills/api-spec-contract-review/SKILL.md" \
+          "openapi/index.yml"; do
+          if [ ! -f "$required" ]; then
+            echo "::error::Required file missing after prepare: $required" >&2
+            exit 1
+          fi
+        done
 
     - name: Install Cursor CLI
       shell: bash
@@ -87,8 +105,16 @@ runs:
         PR_NUM: ${{ github.event.pull_request.number }}
         MODEL: kimi-k2.5
       run: |
-        set -e
+        set -euo pipefail
         export PATH="${CURSOR_BIN:-$HOME/.cursor/bin}:$PATH"
+        for required in \
+          ".cursor/skills/api-spec-contract-review/SKILL.md" \
+          "openapi/index.yml"; do
+          if [ ! -f "$required" ]; then
+            echo "::error::Missing $required — run the Prepare step successfully or fix api-documentation layout." >&2
+            exit 1
+          fi
+        done
         CHANGED_FILES=$(gh pr diff "$PR_NUM" --name-only 2>/dev/null | head -100 || true)
         PROMPT="/api-spec-contract-review
 

--- a/api-docs-compliance/action.yml
+++ b/api-docs-compliance/action.yml
@@ -1,5 +1,5 @@
 name: 'API Documentation Compliance'
-description: 'Checks OpenAPI spec compliance on PRs using shared api-documentation rules.'
+description: 'Checks OpenAPI spec compliance on PRs using the api-spec-contract-review skill from api-documentation.'
 inputs:
   PERSONAL_ACCESS_TOKEN:
     description: 'GitHub token with access to the api-documentation repo (if private)'
@@ -61,11 +61,12 @@ runs:
           cartoncloud-robot
           github-actions[bot]
 
-    - name: Prepare API spec bugbot rules
+    - name: Prepare API spec contract review skill and OpenAPI spec
       shell: bash
       run: |
-        mkdir -p .github/rules
-        cp api-documentation/.cursor/rules/api-spec-rules/RULE.mdc .github/rules/api-spec-openapi-bugbot.prompt
+        mkdir -p .cursor/skills
+        cp -r api-documentation/.cursor/skills/api-spec-contract-review .cursor/skills/
+        cp -r api-documentation/openapi openapi
 
     - name: Install Cursor CLI
       shell: bash
@@ -74,7 +75,7 @@ runs:
         echo "$HOME/.cursor/bin" >> $GITHUB_PATH
         echo "CURSOR_BIN=$HOME/.cursor/bin" >> $GITHUB_ENV
 
-    - name: Run OpenAPI spec bugbot (Cursor CLI)
+    - name: Run OpenAPI spec contract review (Cursor CLI)
       id: bugbot
       shell: bash
       env:
@@ -86,16 +87,10 @@ runs:
       run: |
         set -e
         export PATH="${CURSOR_BIN:-$HOME/.cursor/bin}:$PATH"
-        RULE_PROMPT=$(cat .github/rules/api-spec-openapi-bugbot.prompt)
         CHANGED_FILES=$(gh pr diff "$PR_NUM" --name-only 2>/dev/null | head -100 || true)
-        OPENAPI_SPEC="openapi/index.yml"
-        [ -d api-documentation/openapi ] && OPENAPI_SPEC="api-documentation/openapi/index.yml"
-        PROMPT="${RULE_PROMPT}
+        PROMPT="/api-spec-contract-review
 
-        ---
-        Context for this run:
-        - OpenAPI contract (canonical): ${OPENAPI_SPEC}
-        - Files changed in this PR (review only these):
+        Files changed in this PR (review only these):
         ${CHANGED_FILES}
 
         Output your full review to stdout. If no violations, output exactly COMPLIANT_NO_VIOLATIONS first."
@@ -117,7 +112,7 @@ runs:
           echo "Bugbot produced no output; posting review to request re-run or log check."
           FIRST_FILE=$(gh pr diff "$PR_NUM" --name-only 2>/dev/null | head -n1)
           FIRST_FILE=${FIRST_FILE:-README.md}
-          BODY="**API spec review (API Documentation Compliance).** Bugbot produced no output. This may indicate agent timeout, no matching changed files, or a CLI error. Please check the workflow logs for the 'Run OpenAPI spec bugbot' step and re-run the workflow if needed."
+          BODY="**API spec review (API Documentation Compliance).** Contract review produced no output. This may indicate agent timeout, no matching changed files, or a CLI error. Please check the workflow logs for the 'Run OpenAPI spec contract review' step and re-run the workflow if needed."
           jq -n \
             --arg path "$FIRST_FILE" \
             --arg body "$BODY" \

--- a/api-docs-compliance/action.yml
+++ b/api-docs-compliance/action.yml
@@ -66,7 +66,9 @@ runs:
       run: |
         mkdir -p .cursor/skills
         cp -r api-documentation/.cursor/skills/api-spec-contract-review .cursor/skills/
-        cp -r api-documentation/openapi openapi
+        # Merge canonical spec into openapi/ so it ends up at openapi/index.yml even when repo already has openapi/
+        mkdir -p openapi
+        rsync -a api-documentation/openapi/ openapi/
 
     - name: Install Cursor CLI
       shell: bash


### PR DESCRIPTION
Example output for service-file
https://github.com/cartoncloud/service-file/pull/289

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Updates a composite GitHub Action used for PR compliance checks; failures or path/layout mismatches could stop API spec reviews from running and affect merge gating.
> 
> **Overview**
> **Migrates the API Documentation Compliance action from a rule-based prompt to a Cursor skill.** The workflow now copies the `api-spec-contract-review` skill from the `api-documentation` repo and invokes it via the `/api-spec-contract-review` prompt instead of reading a `.mdc` rule file.
> 
> **Hardens setup and standardizes spec location.** It rsyncs the canonical `api-documentation/openapi/` into the repo’s `openapi/` folder (ensuring `openapi/index.yml`), adds required-file checks, and tightens bash error handling (`set -euo pipefail`), with updated messaging for “no output” cases.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 55dac854178bb27919dbb69115ed411ff310cec5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->