### PR TITLE
PLT-2086: Always redeploy on deploy

### DIFF
--- a/deploy-java/action.yml
+++ b/deploy-java/action.yml
@@ -140,7 +140,6 @@ runs:
         aws-region: ${{ inputs.awsRegion }}
 
     - name: Deploy to ECS
-      if: steps.deploy-check.outputs.existing == '' || steps.version-tag.outputs.restart == 'true'
       shell: bash
       env:
         CLUSTER_NAME: ${{ inputs.clusterName || format('services-{0}', inputs.environmentTag) }}

--- a/deploy-java/action.yml
+++ b/deploy-java/action.yml
@@ -131,7 +131,6 @@ runs:
       run: |
         manifest=$(aws ecr batch-get-image --region us-west-2 --repository-name ${{ inputs.appName }} --image-ids imageTag=${{ inputs.existingImageTag }} --output json | jq --raw-output --join-output '.images[0].imageManifest')
         aws ecr put-image --region us-west-2 --repository-name ${{ inputs.appName }} --image-tag ${{ inputs.versionTag }} --image-manifest "$manifest" || echo "Tag already exists"
-        echo "restart=true" >> $GITHUB_OUTPUT
 
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v6


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes deployment behavior so `Deploy to ECS` always runs (and always forces a new ECS deployment), which can increase deployment frequency and surface issues in CI/CD behavior rather than application code.
> 
> **Overview**
> Ensures the `deploy-java` composite action *always* triggers an ECS redeploy by removing the conditional gate on the `Deploy to ECS` step.
> 
> Also drops the unused `restart` output previously set during version-tagging, simplifying tagging logic while keeping existing ECR tagging behavior intact.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 491653cf95eca72ce0b784cad3df20b45c36930c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->