### PR TITLE
CC-45210 skip posting comment if no violations

### DIFF
--- a/api-docs-compliance/action.yml
+++ b/api-docs-compliance/action.yml
@@ -121,7 +121,7 @@ runs:
         Files changed in this PR (review only these):
         ${CHANGED_FILES}
 
-        Output your full review to stdout. If no violations, output exactly COMPLIANT_NO_VIOLATIONS first."
+        Output your full review to stdout. If no violations, output a line containing only COMPLIANT_NO_VIOLATIONS (no preamble on earlier lines; CI treats any such line as compliant and will not post a PR review)."
         agent --print --output-format=text --model "$MODEL" --trust --workspace "$GITHUB_WORKSPACE" -- "$PROMPT" > /tmp/bugbot-output.txt 2>/tmp/bugbot-stderr.txt || true
         [ -s /tmp/bugbot-stderr.txt ] && cat /tmp/bugbot-stderr.txt >&2 || true
 
@@ -134,7 +134,9 @@ runs:
         PR_NUM: ${{ github.event.pull_request.number }}
       run: |
         set -e
-        if head -n1 /tmp/bugbot-output.txt 2>/dev/null | grep -qFx "COMPLIANT_NO_VIOLATIONS"; then
+        # Do not rely on line 1 only — the agent often prints a preamble; the skill still outputs
+        # COMPLIANT_NO_VIOLATIONS as its verdict line. Match any line that is only that token (trimmed).
+        if [ -f /tmp/bugbot-output.txt ] && tr -d '\r' < /tmp/bugbot-output.txt | grep -qE '^[[:space:]]*COMPLIANT_NO_VIOLATIONS[[:space:]]*$'; then
           echo "API spec check passed (COMPLIANT_NO_VIOLATIONS). No review posted."
           exit 0
         fi

--- a/api-docs-compliance/action.yml
+++ b/api-docs-compliance/action.yml
@@ -121,7 +121,7 @@ runs:
         Files changed in this PR (review only these):
         ${CHANGED_FILES}
 
-        Output your full review to stdout. If no violations, output a line containing only COMPLIANT_NO_VIOLATIONS (no preamble on earlier lines; CI treats any such line as compliant and will not post a PR review)."
+        Output your full review to stdout. If no violations, the first non-empty line must be exactly COMPLIANT_NO_VIOLATIONS (you may add a brief confirmation on following lines). If you report violations, do not put that token on its own line anywhere — CI only treats compliance when that token is the first non-empty line."
         agent --print --output-format=text --model "$MODEL" --trust --workspace "$GITHUB_WORKSPACE" -- "$PROMPT" > /tmp/bugbot-output.txt 2>/tmp/bugbot-stderr.txt || true
         [ -s /tmp/bugbot-stderr.txt ] && cat /tmp/bugbot-stderr.txt >&2 || true
 
@@ -134,9 +134,14 @@ runs:
         PR_NUM: ${{ github.event.pull_request.number }}
       run: |
         set -e
-        # Do not rely on line 1 only — the agent often prints a preamble; the skill still outputs
-        # COMPLIANT_NO_VIOLATIONS as its verdict line. Match any line that is only that token (trimmed).
-        if [ -f /tmp/bugbot-output.txt ] && tr -d '\r' < /tmp/bugbot-output.txt | grep -qE '^[[:space:]]*COMPLIANT_NO_VIOLATIONS[[:space:]]*$'; then
+        # Anchor to the first non-empty line only (trimmed). Matching any line would let a violation
+        # report pass if the model quoted COMPLIANT_NO_VIOLATIONS on its own line mid-output.
+        # Leading blank lines are skipped; compliant output may continue after the verdict (per skill).
+        first_nonempty=
+        if [ -f /tmp/bugbot-output.txt ]; then
+          first_nonempty=$(tr -d '\r' < /tmp/bugbot-output.txt | awk '/[^[:space:]]/ { gsub(/^[[:space:]]+|[[:space:]]+$/, ""); print; exit }')
+        fi
+        if [ "$first_nonempty" = "COMPLIANT_NO_VIOLATIONS" ]; then
           echo "API spec check passed (COMPLIANT_NO_VIOLATIONS). No review posted."
           exit 0
         fi


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk workflow-only change that adjusts how the compliance verdict token is interpreted to avoid false passes when the model echoes the token in violation output.
> 
> **Overview**
> Updates the `api-docs-compliance` composite action to **make compliance detection stricter**: the Cursor skill is instructed that `COMPLIANT_NO_VIOLATIONS` must be the *first non-empty line*, and the workflow now parses `/tmp/bugbot-output.txt` accordingly (skipping blanks, trimming whitespace, stripping CRLF).
> 
> This prevents CI from treating a violation report as compliant if the model happens to include `COMPLIANT_NO_VIOLATIONS` on its own line later in the output, while still allowing extra confirmation lines after a compliant verdict.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 41dbe640786c6a651e46de99fca3aa85adbb0d0e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->