### PR TITLE
CC-45210 still posts comment if COMPLIANT_NO_VIOLATIONS in Conclusion…

### DIFF
--- a/api-docs-compliance/action.yml
+++ b/api-docs-compliance/action.yml
@@ -121,7 +121,7 @@ runs:
         Files changed in this PR (review only these):
         ${CHANGED_FILES}
 
-        Output your full review to stdout. If no violations, the first non-empty line must be exactly COMPLIANT_NO_VIOLATIONS (you may add a brief confirmation on following lines). If you report violations, do not put that token on its own line anywhere — CI only treats compliance when that token is the first non-empty line."
+        Output your full review to stdout. If no violations, include a line that is exactly COMPLIANT_NO_VIOLATIONS (e.g. first line or under a Conclusion heading). If you report violations, do not put that token on its own line anywhere — CI treats compliance only when that exact line appears."
         agent --print --output-format=text --model "$MODEL" --trust --workspace "$GITHUB_WORKSPACE" -- "$PROMPT" > /tmp/bugbot-output.txt 2>/tmp/bugbot-stderr.txt || true
         [ -s /tmp/bugbot-stderr.txt ] && cat /tmp/bugbot-stderr.txt >&2 || true
 
@@ -134,14 +134,20 @@ runs:
         PR_NUM: ${{ github.event.pull_request.number }}
       run: |
         set -e
-        # Anchor to the first non-empty line only (trimmed). Matching any line would let a violation
-        # report pass if the model quoted COMPLIANT_NO_VIOLATIONS on its own line mid-output.
-        # Leading blank lines are skipped; compliant output may continue after the verdict (per skill).
-        first_nonempty=
-        if [ -f /tmp/bugbot-output.txt ]; then
-          first_nonempty=$(tr -d '\r' < /tmp/bugbot-output.txt | awk '/[^[:space:]]/ { gsub(/^[[:space:]]+|[[:space:]]+$/, ""); print; exit }')
+        # Compliant when COMPLIANT_NO_VIOLATIONS appears on its own line (trimmed). The model may
+        # put that verdict under a Conclusion heading rather than as the first line of the report.
+        # Violation reports must not put that token on its own line anywhere (per prompt/skill).
+        compliant=
+        if [ -f /tmp/bugbot-output.txt ] && tr -d '\r' < /tmp/bugbot-output.txt | awk '
+          /^[[:space:]]*$/ { next }
+          { gsub(/^[[:space:]]+|[[:space:]]+$/, "", $0)
+            if ($0 == "COMPLIANT_NO_VIOLATIONS") { found=1; exit }
+          }
+          END { exit !found }
+        '; then
+          compliant=1
         fi
-        if [ "$first_nonempty" = "COMPLIANT_NO_VIOLATIONS" ]; then
+        if [ -n "$compliant" ]; then
           echo "API spec check passed (COMPLIANT_NO_VIOLATIONS). No review posted."
           exit 0
         fi


### PR DESCRIPTION
… section

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk workflow logic tweak limited to how the action parses the model output to decide whether to post a PR review.
> 
> **Overview**
> Updates the `api-docs-compliance` composite action so compliance is detected when `COMPLIANT_NO_VIOLATIONS` appears *anywhere* on its own trimmed line (not just as the first non-empty line), matching the updated prompt guidance.
> 
> This prevents the workflow from posting a violations review when the model places the verdict under a `Conclusion` section.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 97fe3ae16e68f0f91ab95b5e35fe115eba50a47d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->