### PR TITLE
add errors true to determine what the problem with new action is.

### DIFF
--- a/.github/workflows/shared-release-pull-request-java.yml
+++ b/.github/workflows/shared-release-pull-request-java.yml
@@ -404,6 +404,7 @@ jobs:
           method: chat.postMessage
           token: ${{ secrets.SLACK_BOT_TOKEN }}
           payload: ${{ needs.create-releases.outputs.slackReleaseNotes }}
+          errors: true
 
   deploy-production:
     name: Deploy to Production

--- a/jira-release-notes-slack/dist/index.js
+++ b/jira-release-notes-slack/dist/index.js
@@ -29702,7 +29702,7 @@ async function run() {
       repoUrl,
       slackChannel
     });
-    setOutput("releaseNotes", slackJson);
+    setOutput("releaseNotes", JSON.stringify(slackJson));
   } catch (error2) {
     setFailed(error2.message);
   }

--- a/jira-release-notes-slack/src/index.ts
+++ b/jira-release-notes-slack/src/index.ts
@@ -23,7 +23,7 @@ async function run() {
       repoUrl: repoUrl,
       slackChannel,
     });
-    core.setOutput('releaseNotes', slackJson);
+    core.setOutput("releaseNotes", JSON.stringify(slackJson));
   } catch (error: any) {
     core.setFailed(error.message);
   }


### PR DESCRIPTION
I couldn't locate the issue in the v3 action adding errors:true to get better logging on error.
This will not break deployments as we continue on errors.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the release/deploy GitHub Actions workflow and a custom action output format, which could impact Slack notifications and downstream steps if the payload/outputs are parsed differently.
> 
> **Overview**
> **Improves release Slack notifications debugging and payload handling.** The `Release Notes` Slack step in `shared-release-pull-request-java.yml` now sets `errors: true` for `slackapi/slack-github-action` to surface API errors while still `continue-on-error`.
> 
> The `jira-release-notes-slack` action now `JSON.stringify`s the generated Slack payload before setting the `releaseNotes` output (and updates the bundled `dist/index.js` accordingly), ensuring outputs are emitted as strings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 917326887b28b89395f38e2c2704d9c6f862f123. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->