### PR TITLE
change chanel to releases

### DIFF
--- a/.github/workflows/shared-release-pull-request-java.yml
+++ b/.github/workflows/shared-release-pull-request-java.yml
@@ -398,7 +398,7 @@ jobs:
     steps:
       - name: Slack notification
         uses: slackapi/slack-github-action@v3.0.1
-        if: vars.DEPLOY_SLACK_CHANNEL_ID != '' && needs.create-releases.outputs.slackReleaseNotes != ''
+        if: needs.create-releases.outputs.slackReleaseNotes != ''
         continue-on-error: true
         with:
           method: chat.postMessage

--- a/.github/workflows/shared-release-pull-request-java.yml
+++ b/.github/workflows/shared-release-pull-request-java.yml
@@ -352,7 +352,7 @@ jobs:
         with:
           title: ${{ inputs.appName }} ${{ steps.increment-version.outputs.new_tag }}
           slackToken: ${{ secrets.SLACK_BOT_TOKEN }}
-          slackChannel: ${{ vars.DEPLOY_SLACK_CHANNEL_ID }}
+          slackChannel: ${{ vars.SLACK_RELEASES_CHANNEL_ID }}
 
       - name: Create release
         uses: ncipollo/release-action@v1


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk workflow-only change affecting where release-note notifications are posted in Slack and when the Slack notification step runs.
> 
> **Overview**
> Release note Slack output in `shared-release-pull-request-java.yml` is now targeted at `vars.SLACK_RELEASES_CHANNEL_ID` instead of `vars.DEPLOY_SLACK_CHANNEL_ID`.
> 
> The `release-notes` job no longer gates the Slack post on `DEPLOY_SLACK_CHANNEL_ID` being set; it only checks that generated Slack release notes are non-empty.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a9d9f411950b8a27b3d24d70133b9c990e8638e0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->