### PR TITLE
CC-47010 - Tune permission risk cues in PR review

### DIFF
--- a/.github/workflows/pr-risk-review.yml
+++ b/.github/workflows/pr-risk-review.yml
@@ -101,8 +101,13 @@ jobs:
           - low: user-visible copy only, UI labels/help text, translations, comments, static docs,
             history/audit log messages that do not affect permissions, billing, or security behavior,
             or purely cosmetic presentation with no logic or data changes.
+            Permission changes are low risk only when adding **new** permissions (new capability keys,
+            new role-action pairs, new feature flags scoped to authorization) **without** changing how
+            any **existing** permission is interpreted, enforced, or assigned.
           - high: billing/payments/invoicing/subscriptions/pricing/refunds/credits; authentication,
-            authorization, sessions, passwords, tokens, OAuth, roles/permissions; secrets or production
+            authorization, sessions, passwords, tokens, OAuth, roles/permissions; modifying **existing**
+            permissions is high risk (changed semantics, enforcement, conditions, mappings, defaults,
+            or what existing roles/users can do—even if wording or structure looks small); secrets or production
             credentials; changes to how PII or money moves; security-sensitive crypto; external
             integrations or webhooks that affect charging, identity, or regulated data; migrations
             or config that alter financial or auth enforcement.


### PR DESCRIPTION
### Why?

The automated PR risk classifier should treat additive permission declarations differently from edits to existing permission behavior, matching how teams usually review RBAC-related changes.

### How?

Sharpen the embedded Composer classifier prompt so narrowly scoped additions of new permissions qualify for low-risk classification while any change that alters interpretation, enforcement, or assignment of existing permissions is flagged as high risk.

---

CC-47010

<sub>Generated with Cursor</sub>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Updates the risk-classifier prompt that drives automated labels/approvals; misclassification could lead to inappropriate auto-approval or extra review requirements for permission-related PRs.
> 
> **Overview**
> Tightens the `pr-risk-review.yml` classifier guidelines so **additive** RBAC changes (adding *new* permissions/role-action pairs/feature flags) can be treated as `low` risk, while **any modification of existing permission semantics/enforcement/assignment** is explicitly called out as `high` risk.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0c35c134dd63d1bd270e64b7b6c180b545a27d7f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->