### PR TITLE
CC-47010 - Add analytics instrumentation to PR risk low criteria

### DIFF
--- a/.github/workflows/pr-risk-review.yml
+++ b/.github/workflows/pr-risk-review.yml
@@ -100,7 +100,8 @@ jobs:
           Guidelines:
           - low: user-visible copy only, UI labels/help text, translations, comments, static docs,
             history/audit log messages that do not affect permissions, billing, or security behavior,
-            or purely cosmetic presentation with no logic or data changes.
+            or purely cosmetic presentation with no logic or data changes, or analytics instrumentation
+            only.
             Permission changes are low risk only when adding **new** permissions (new capability keys,
             new role-action pairs, new feature flags scoped to authorization) **without** changing how
             any **existing** permission is interpreted, enforced, or assigned.


### PR DESCRIPTION
## Summary

- Extend the PR risk review classifier prompt so changes limited to analytics instrumentation can be classified as low risk alongside copy-only and cosmetic UI updates.

## Test plan

- [ ] Confirm wording reads correctly in `.github/workflows/pr-risk-review.yml`.
- [ ] After merge, spot-check a caller repo workflow run once updated to this revision.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only updates the risk-classification prompt text in `.github/workflows/pr-risk-review.yml`, with no code-path or permission/labeling logic changes. Low risk aside from potentially shifting automated risk labeling for analytics-only PRs.
> 
> **Overview**
> Updates the reusable workflow `.github/workflows/pr-risk-review.yml` to explicitly treat *analytics instrumentation-only* PRs as **low risk** in the risk classifier guidelines.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit db5cad30b225a7ec299851cae6c58a14dc42c164. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->