### PR TITLE
Bump PR risk review classifier to Composer 2.5

### DIFF
--- a/.github/workflows/pr-risk-review.yml
+++ b/.github/workflows/pr-risk-review.yml
@@ -18,7 +18,7 @@
 # Prerequisites on the caller repository:
 # - Actions secret: CURSOR_API_KEY (https://cursor.com/docs/cli/reference/authentication)
 #
-# Classifier model: Cursor Composer 2 (`composer-2`).
+# Classifier model: Cursor Composer 2.5 (`composer-2.5`).
 #
 # Branch protection: GitHub cannot set "1 reviewer for low / 2 for high" per PR in native rules.
 # Typical setup: require one approval; github-actions approves low-risk same-repo PRs so one human may suffice.
@@ -88,7 +88,7 @@ jobs:
           CURSOR_API_KEY: ${{ secrets.CURSOR_API_KEY }}
         run: |
           set +e
-          agent -p -f --output-format json --model composer-2 "$(cat <<'EOF'
+          agent -p -f --output-format json --model composer-2.5 "$(cat <<'EOF'
           You classify pull-request risk for a production web application.
 
           Read these workspace files:
@@ -226,7 +226,7 @@ jobs:
           signals = data.get("signals") or []
 
           lines = [
-              "### Automated risk review (Composer 2)",
+              "### Automated risk review",
               "",
               f"**Level:** `risk: {risk}`",
               "",
@@ -326,4 +326,4 @@ jobs:
           if gh pr view "$PR" --json reviewDecision --jq '.reviewDecision == "APPROVED"' | grep -q true; then
             exit 0
           fi
-          gh pr review "$PR" --approve --body "Automated low-risk classification (Composer 2 risk review). One human reviewer may still be required by branch protection."
+          gh pr review "$PR" --approve --body "Automated low-risk classification. One human reviewer may still be required by branch protection."


### PR DESCRIPTION
### Why?

Keep the reusable PR risk review workflow on the current Cursor Composer classifier so automated risk labels stay accurate.

### How?

Point the workflow agent at `composer-2.5` and align header/approval copy with the generic automated risk review branding.

<sub>Generated with Cursor</sub>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only change that updates the model version and modifies comment/approval text; low risk aside from potentially altering automated risk classifications.
> 
> **Overview**
> Bumps the PR risk review GitHub Actions workflow to run the Cursor agent with `--model composer-2.5` (and updates the header comment to match).
> 
> Refreshes the sticky comment title and auto-approval body copy to generic “Automated risk review” wording (removing explicit “Composer 2” references).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dfb95a1762cb5ac8678d41c8be7c5fe12b7c4877. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->