### PR TITLE
Add shared AI feedback workflows for spec and ticket PR merges

### DIFF
--- a/.github/workflows/shared-ai-feedback-spec-merged.yml
+++ b/.github/workflows/shared-ai-feedback-spec-merged.yml
@@ -1,0 +1,179 @@
+name: AI Feedback — Spec Merged
+
+# Reusable workflow — call this from api-documentation on PR merge.
+#
+# Caller snippet (add to api-documentation/.github/workflows/ai-feedback-on-merge.yml):
+#
+#   on:
+#     pull_request:
+#       types: [closed]
+#       branches: [main]
+#   jobs:
+#     spec-feedback:
+#       if: github.event.pull_request.merged == true
+#       uses: cartoncloud/actions/.github/workflows/shared-ai-feedback-spec-merged.yml@main
+#       with:
+#         pr_title:         ${{ github.event.pull_request.title }}
+#         pr_url:           ${{ github.event.pull_request.html_url }}
+#         pr_branch:        ${{ github.event.pull_request.head.ref }}
+#         pr_number:        ${{ github.event.pull_request.number }}
+#         merged_by:        ${{ github.event.pull_request.merged_by.login }}
+#         github_slack_map: ${{ vars.GITHUB_SLACK_MAP }}
+#         slack_channel_id: ${{ vars.SLACK_AI_FEEDBACK_CHANNEL_ID }}
+#       secrets:
+#         SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+#
+# Required secret (set at org level or in api-documentation):
+#   SLACK_BOT_TOKEN    Slack bot token with chat:write scope
+#
+# Required variable (set at org level or in api-documentation):
+#   SLACK_AI_FEEDBACK_CHANNEL_ID    Channel ID for #ai-reinforcement-tweaks (or test channel)
+#
+# Optional variable (org-level or repo-level):
+#   GITHUB_SLACK_MAP    JSON string {"githubUsername": "USLACKID"} — enables real @mentions.
+#                       See scripts/github-slack-map.json in local-environment for the source of truth.
+
+on:
+  workflow_call:
+    inputs:
+      pr_title:
+        description: PR title
+        type: string
+        required: true
+      pr_url:
+        description: PR HTML URL
+        type: string
+        required: true
+      pr_branch:
+        description: Head branch ref (e.g. story/CC-1234)
+        type: string
+        required: true
+      pr_number:
+        description: PR number — used to fetch review round count
+        type: string
+        required: true
+      merged_by:
+        description: GitHub username of the person who merged
+        type: string
+        required: true
+      github_slack_map:
+        description: JSON string mapping GitHub usernames to Slack member IDs
+        type: string
+        required: false
+        default: "{}"
+      slack_channel_id:
+        description: Slack channel ID to post to (from vars.SLACK_AI_FEEDBACK_CHANNEL_ID)
+        type: string
+        required: true
+    secrets:
+      SLACK_BOT_TOKEN:
+        required: true
+
+jobs:
+  notify:
+    name: Post spec feedback prompt to Slack
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Send Slack feedback prompt
+        env:
+          FEEDBACK_TYPE: spec
+          PR_TITLE: ${{ inputs.pr_title }}
+          PR_URL: ${{ inputs.pr_url }}
+          PR_BRANCH: ${{ inputs.pr_branch }}
+          PR_NUMBER: ${{ inputs.pr_number }}
+          MERGED_BY: ${{ inputs.merged_by }}
+          GITHUB_SLACK_MAP: ${{ inputs.github_slack_map }}
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+          SLACK_AI_FEEDBACK_CHANNEL_ID: ${{ inputs.slack_channel_id }}
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          node << 'NODEEOF'
+          const TICKET_RE = /\b(CC[-_ ]?\d+)\b/i;
+
+          function getEnv(k, required = true) {
+            const v = (process.env[k] || "").trim();
+            if (required && !v) { console.error("Missing required env var: " + k); process.exit(1); }
+            return v;
+          }
+
+          async function fetchJson(url, opts = {}) {
+            const res = await fetch(url, opts);
+            if (!res.ok) { const b = await res.text(); throw new Error("HTTP " + res.status + ": " + b.slice(0, 300)); }
+            return res.json();
+          }
+
+          function extractTicketKey(title, branch) {
+            const m = (title + " " + branch).match(TICKET_RE);
+            if (!m) return null;
+            return m[1].toUpperCase().replace(/^(CC)[-_ ]?(\d+)$/, "CC-$2");
+          }
+
+          function slackMention(githubUser, mapStr) {
+            try { const map = JSON.parse(mapStr || "{}"); if (map[githubUser]) return "<@" + map[githubUser] + ">"; } catch {}
+            return "@" + githubUser;
+          }
+
+          async function countReviewRounds(owner, repo, prNumber, token) {
+            const reviews = await fetchJson(
+              "https://api.github.com/repos/" + owner + "/" + repo + "/pulls/" + prNumber + "/reviews?per_page=100",
+              { headers: { Authorization: "Bearer " + token, Accept: "application/vnd.github+json", "X-GitHub-Api-Version": "2022-11-28" } }
+            );
+            return Array.isArray(reviews) ? reviews.filter(r => r.state === "CHANGES_REQUESTED").length : 0;
+          }
+
+          async function postSlack(token, channelId, text) {
+            const res = await fetch("https://slack.com/api/chat.postMessage", {
+              method: "POST",
+              headers: { Authorization: "Bearer " + token, "Content-Type": "application/json" },
+              body: JSON.stringify({ channel: channelId, text, mrkdwn: true }),
+            });
+            const data = await res.json();
+            if (!data.ok) throw new Error("Slack API error: " + data.error);
+          }
+
+          async function main() {
+            const prTitle     = getEnv("PR_TITLE", false);
+            const prBranch    = getEnv("PR_BRANCH", false);
+            const prUrl       = getEnv("PR_URL");
+            const mergedBy    = getEnv("MERGED_BY");
+            const prNumber    = getEnv("PR_NUMBER", false);
+            const slackToken  = getEnv("SLACK_BOT_TOKEN");
+            const channelId   = getEnv("SLACK_AI_FEEDBACK_CHANNEL_ID");
+            const ghToken     = getEnv("GITHUB_TOKEN");
+            const slackMapStr = getEnv("GITHUB_SLACK_MAP", false);
+
+            const ticketKey = extractTicketKey(prTitle, prBranch);
+            if (!ticketKey) { console.log("No CC-XXXX ticket key found — skipping."); return; }
+
+            const mention    = slackMention(mergedBy, slackMapStr);
+            const ticketLink = "<" + prUrl + "|" + ticketKey + ">";
+
+            let roundsLine = "";
+            if (prNumber) {
+              const [owner, repo] = (getEnv("GITHUB_REPOSITORY", false) || "cartoncloud/api-documentation").split("/");
+              try {
+                const rounds = await countReviewRounds(owner, repo, prNumber, ghToken);
+                roundsLine = rounds === 0
+                  ? "\n*Review rounds: 0 \u2014 approved first pass :tada:*"
+                  : "\n*Review rounds: " + rounds + "*";
+              } catch (e) { console.warn("Could not fetch review rounds: " + e.message); }
+            }
+
+            const text = [
+              mention + " :clipboard: Spec merged: " + ticketLink + ". Drop a reply in :thread:" + roundsLine,
+              "\u2022 What kept coming up across those rounds?",
+              "\u2022 What's one thing that worked well in the process?",
+              "\u2022 Anything that should change in `/start-spec` or any other part of the process off the back of this?",
+            ].join("\n");
+
+            await postSlack(slackToken, channelId, text);
+            console.log("Slack notification sent for " + ticketKey + " (spec)");
+          }
+
+          main().catch(e => { console.error(e.message || String(e)); process.exit(2); });
+          NODEEOF

--- a/.github/workflows/shared-ai-feedback-ticket-merged.yml
+++ b/.github/workflows/shared-ai-feedback-ticket-merged.yml
@@ -1,0 +1,171 @@
+name: AI Feedback — Ticket Merged
+
+# Reusable workflow — call this from any repo (php, js, flutter, android, ios, services)
+# on PR merge. It silently exits if the ticket has no matching spec in api-documentation.
+#
+# Caller snippet (add to each repo at .github/workflows/ai-feedback-on-merge.yml):
+#
+#   on:
+#     pull_request:
+#       types: [closed]
+#       branches: [main]
+#   jobs:
+#     ticket-feedback:
+#       if: github.event.pull_request.merged == true
+#       uses: cartoncloud/actions/.github/workflows/shared-ai-feedback-ticket-merged.yml@main
+#       with:
+#         pr_title:         ${{ github.event.pull_request.title }}
+#         pr_url:           ${{ github.event.pull_request.html_url }}
+#         pr_branch:        ${{ github.event.pull_request.head.ref }}
+#         merged_by:        ${{ github.event.pull_request.merged_by.login }}
+#         github_slack_map: ${{ vars.GITHUB_SLACK_MAP }}
+#         slack_channel_id: ${{ vars.SLACK_AI_FEEDBACK_CHANNEL_ID }}
+#       secrets:
+#         SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+#         GH_READ_TOKEN:   ${{ secrets.GH_READ_TOKEN }}
+#
+# Required secrets (set at org level or in each calling repo):
+#   SLACK_BOT_TOKEN    Slack bot token with chat:write scope
+#   GH_READ_TOKEN      PAT with repo:read access to cartoncloud/api-documentation
+#
+# Required variable (set at org level or in each calling repo):
+#   SLACK_AI_FEEDBACK_CHANNEL_ID    Channel ID for #ai-reinforcement-tweaks (or test channel)
+#
+# Optional variable (org-level or repo-level):
+#   GITHUB_SLACK_MAP    JSON string {"githubUsername": "USLACKID"} — enables real @mentions.
+#                       See scripts/github-slack-map.json in local-environment for the source of truth.
+
+on:
+  workflow_call:
+    inputs:
+      pr_title:
+        description: PR title
+        type: string
+        required: true
+      pr_url:
+        description: PR HTML URL
+        type: string
+        required: true
+      pr_branch:
+        description: Head branch ref (e.g. story/CC-1234)
+        type: string
+        required: true
+      merged_by:
+        description: GitHub username of the person who merged
+        type: string
+        required: true
+      github_slack_map:
+        description: JSON string mapping GitHub usernames to Slack member IDs
+        type: string
+        required: false
+        default: "{}"
+      slack_channel_id:
+        description: Slack channel ID to post to (from vars.SLACK_AI_FEEDBACK_CHANNEL_ID)
+        type: string
+        required: true
+    secrets:
+      SLACK_BOT_TOKEN:
+        required: true
+      GH_READ_TOKEN:
+        required: true
+
+jobs:
+  notify:
+    name: Post ticket feedback prompt to Slack
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Send Slack feedback prompt
+        env:
+          FEEDBACK_TYPE: ticket
+          PR_TITLE: ${{ inputs.pr_title }}
+          PR_URL: ${{ inputs.pr_url }}
+          PR_BRANCH: ${{ inputs.pr_branch }}
+          MERGED_BY: ${{ inputs.merged_by }}
+          GITHUB_SLACK_MAP: ${{ inputs.github_slack_map }}
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+          SLACK_AI_FEEDBACK_CHANNEL_ID: ${{ inputs.slack_channel_id }}
+          GITHUB_TOKEN: ${{ secrets.GH_READ_TOKEN }}
+        run: |
+          node << 'NODEEOF'
+          const TICKET_RE = /\b(CC[-_ ]?\d+)\b/i;
+
+          function getEnv(k, required = true) {
+            const v = (process.env[k] || "").trim();
+            if (required && !v) { console.error("Missing required env var: " + k); process.exit(1); }
+            return v;
+          }
+
+          async function fetchJson(url, opts = {}) {
+            const res = await fetch(url, opts);
+            if (!res.ok) { const b = await res.text(); throw new Error("HTTP " + res.status + ": " + b.slice(0, 300)); }
+            return res.json();
+          }
+
+          function extractTicketKey(title, branch) {
+            const m = (title + " " + branch).match(TICKET_RE);
+            if (!m) return null;
+            return m[1].toUpperCase().replace(/^(CC)[-_ ]?(\d+)$/, "CC-$2");
+          }
+
+          function slackMention(githubUser, mapStr) {
+            try { const map = JSON.parse(mapStr || "{}"); if (map[githubUser]) return "<@" + map[githubUser] + ">"; } catch {}
+            return "@" + githubUser;
+          }
+
+          async function hasSpecPr(ticketKey, token) {
+            const q = encodeURIComponent(ticketKey + " repo:cartoncloud/api-documentation is:pr is:merged");
+            const data = await fetchJson(
+              "https://api.github.com/search/issues?q=" + q + "&per_page=1",
+              { headers: { Authorization: "Bearer " + token, Accept: "application/vnd.github+json", "X-GitHub-Api-Version": "2022-11-28" } }
+            );
+            return (data?.total_count ?? 0) > 0;
+          }
+
+          async function postSlack(token, channelId, text) {
+            const res = await fetch("https://slack.com/api/chat.postMessage", {
+              method: "POST",
+              headers: { Authorization: "Bearer " + token, "Content-Type": "application/json" },
+              body: JSON.stringify({ channel: channelId, text, mrkdwn: true }),
+            });
+            const data = await res.json();
+            if (!data.ok) throw new Error("Slack API error: " + data.error);
+          }
+
+          async function main() {
+            const prTitle     = getEnv("PR_TITLE", false);
+            const prBranch    = getEnv("PR_BRANCH", false);
+            const prUrl       = getEnv("PR_URL");
+            const mergedBy    = getEnv("MERGED_BY");
+            const slackToken  = getEnv("SLACK_BOT_TOKEN");
+            const channelId   = getEnv("SLACK_AI_FEEDBACK_CHANNEL_ID");
+            const ghToken     = getEnv("GITHUB_TOKEN");
+            const slackMapStr = getEnv("GITHUB_SLACK_MAP", false);
+
+            const ticketKey = extractTicketKey(prTitle, prBranch);
+            if (!ticketKey) { console.log("No CC-XXXX ticket key found — skipping."); return; }
+
+            const found = await hasSpecPr(ticketKey, ghToken);
+            if (!found) { console.log("No merged spec found for " + ticketKey + " in api-documentation — skipping."); return; }
+
+            const mention    = slackMention(mergedBy, slackMapStr);
+            const ticketLink = "<" + prUrl + "|" + ticketKey + ">";
+
+            const text = [
+              mention + " :rocket: " + ticketLink + " merged for release. Drop a reply in :thread:",
+              "\u2022 Did the spec hold up when you ran the bot, or did you have to patch it mid-build?",
+              "\u2022 End to end \u2014 spec through to shipped PR \u2014 faster than how you worked before?",
+              "\u2022 Any cursor rules added or updated as a result?",
+              "\u2022 What's one thing that went well you'd want others to know?",
+            ].join("\n");
+
+            await postSlack(slackToken, channelId, text);
+            console.log("Slack notification sent for " + ticketKey + " (ticket)");
+          }
+
+          main().catch(e => { console.error(e.message || String(e)); process.exit(2); });
+          NODEEOF


### PR DESCRIPTION
Add two reusable workflows to cartoncloud/actions for posting AI feedback prompts to Slack on PR merge:

- shared-ai-feedback-spec-merged.yml: call from api-documentation when a spec PR merges; prompts the author to reflect on the spec process
- shared-ai-feedback-ticket-merged.yml: call from any code repo (php, js, flutter, etc.) when a ticket PR merges; silently skips if no matching spec exists in api-documentation

Both workflows are workflow_call only (no direct triggers), use actions/setup-node@v4, and post to a configurable Slack channel via bot token.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it introduces new GitHub Actions that call out to GitHub/Slack APIs using org secrets/PATs; misconfiguration could leak notifications or fail workflows, but it doesn’t touch product runtime code.
> 
> **Overview**
> Adds two reusable `workflow_call` GitHub Actions workflows that post a Slack prompt when a PR is merged.
> 
> `shared-ai-feedback-spec-merged.yml` triggers from the spec repo, extracts a `CC-####` key from title/branch, optionally counts review rounds via the GitHub Reviews API, and posts a threaded feedback prompt to a configurable Slack channel (with optional GitHub→Slack mention mapping).
> 
> `shared-ai-feedback-ticket-merged.yml` does the same for code repos but first checks (via GitHub search against `cartoncloud/api-documentation`) that a matching merged spec PR exists, otherwise it exits without posting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bf408542e8cf63dce8f631dd2c1880083b1fe99c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->