### PR TITLE
Resolve AI feedback Slack mentions at runtime

### DIFF
--- a/.github/workflows/shared-ai-feedback-resolve-mention.yml
+++ b/.github/workflows/shared-ai-feedback-resolve-mention.yml
@@ -81,6 +81,8 @@ jobs:
           }
 
           async function resolveSlackMention(githubUser, slackToken, ghToken, jiraEmail, jiraToken) {
+            if (!githubUser) return "@";
+
             let email = null;
             try {
               const profile = await fetchJson("https://api.github.com/users/" + githubUser, {
@@ -88,7 +90,7 @@ jobs:
               });
               const githubEmail = (profile.email || "").trim().toLowerCase();
               email = githubEmail && !isGithubNoreplyEmail(githubEmail) ? githubEmail : null;
-              if (!email && profile.name) email = await jiraEmailForName(profile.name, jiraEmail, jiraToken);
+              if (!email) email = await jiraEmailForName(profile.name || githubUser, jiraEmail, jiraToken);
             } catch (e) {
               console.warn("Could not resolve email for " + githubUser + ": " + e.message);
             }
@@ -106,7 +108,7 @@ jobs:
           }
 
           async function main() {
-            const githubUser  = getEnv("GITHUB_USER");
+            const githubUser  = getEnv("GITHUB_USER", false);
             const slackToken  = getEnv("SLACK_BOT_TOKEN");
             const ghToken     = getEnv("GITHUB_TOKEN");
             const jiraEmail   = getEnv("JIRA_EMAIL", false);

--- a/.github/workflows/shared-ai-feedback-resolve-mention.yml
+++ b/.github/workflows/shared-ai-feedback-resolve-mention.yml
@@ -1,0 +1,120 @@
+name: AI Feedback — Resolve Slack Mention
+
+on:
+  workflow_call:
+    inputs:
+      github_user:
+        description: GitHub username to resolve
+        type: string
+        required: true
+    secrets:
+      SLACK_BOT_TOKEN:
+        required: true
+      GH_TOKEN:
+        required: true
+      JIRA_EMAIL:
+        required: false
+      JIRA_API_TOKEN:
+        required: false
+    outputs:
+      mention:
+        description: Slack mention or GitHub username fallback
+        value: ${{ jobs.resolve.outputs.mention }}
+
+jobs:
+  resolve:
+    name: Resolve Slack mention
+    runs-on: ubuntu-latest
+    outputs:
+      mention: ${{ steps.resolve.outputs.mention }}
+    steps:
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Resolve Slack mention
+        id: resolve
+        env:
+          GITHUB_USER: ${{ inputs.github_user }}
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+          JIRA_EMAIL: ${{ secrets.JIRA_EMAIL }}
+          JIRA_API_TOKEN: ${{ secrets.JIRA_API_TOKEN }}
+        run: |
+          node << 'NODEEOF'
+          const fs = require("fs");
+
+          function getEnv(k, required = true) {
+            const v = (process.env[k] || "").trim();
+            if (required && !v) { console.error("Missing required env var: " + k); process.exit(1); }
+            return v;
+          }
+
+          async function fetchJson(url, opts = {}) {
+            const res = await fetch(url, opts);
+            if (!res.ok) { const b = await res.text(); throw new Error("HTTP " + res.status + ": " + b.slice(0, 300)); }
+            return res.json();
+          }
+
+          function normalizeName(value) {
+            return (value || "").toLowerCase().replace(/[^a-z0-9]+/g, " ").trim().replace(/\s+/g, " ");
+          }
+
+          function isGithubNoreplyEmail(email) {
+            return /@users\.noreply\.github\.com$/i.test(email);
+          }
+
+          async function jiraEmailForName(name, jiraEmail, jiraToken) {
+            if (!name || !jiraEmail || !jiraToken) return null;
+            const auth = Buffer.from(jiraEmail + ":" + jiraToken).toString("base64");
+            const url = "https://cartoncloud.atlassian.net/rest/api/3/user/search?query=" + encodeURIComponent(name);
+            const users = await fetchJson(url, {
+              headers: { Authorization: "Basic " + auth, Accept: "application/json" },
+            });
+            if (!Array.isArray(users)) return null;
+            const key = normalizeName(name);
+            for (const u of users) {
+              if (normalizeName(u.displayName) === key && u.emailAddress) return u.emailAddress.toLowerCase();
+            }
+            return null;
+          }
+
+          async function resolveSlackMention(githubUser, slackToken, ghToken, jiraEmail, jiraToken) {
+            let email = null;
+            try {
+              const profile = await fetchJson("https://api.github.com/users/" + githubUser, {
+                headers: { Authorization: "Bearer " + ghToken, Accept: "application/vnd.github+json", "X-GitHub-Api-Version": "2022-11-28" },
+              });
+              const githubEmail = (profile.email || "").trim().toLowerCase();
+              email = githubEmail && !isGithubNoreplyEmail(githubEmail) ? githubEmail : null;
+              if (!email && profile.name) email = await jiraEmailForName(profile.name, jiraEmail, jiraToken);
+            } catch (e) {
+              console.warn("Could not resolve email for " + githubUser + ": " + e.message);
+            }
+            if (email) {
+              try {
+                const url = new URL("https://slack.com/api/users.lookupByEmail");
+                url.searchParams.set("email", email);
+                const data = await fetchJson(url, { headers: { Authorization: "Bearer " + slackToken } });
+                if (data.ok && data.user?.id) return "<@" + data.user.id + ">";
+              } catch (e) {
+                console.warn("Slack lookupByEmail failed for " + githubUser + ": " + e.message);
+              }
+            }
+            return "@" + githubUser;
+          }
+
+          async function main() {
+            const githubUser  = getEnv("GITHUB_USER");
+            const slackToken  = getEnv("SLACK_BOT_TOKEN");
+            const ghToken     = getEnv("GITHUB_TOKEN");
+            const jiraEmail   = getEnv("JIRA_EMAIL", false);
+            const jiraToken   = getEnv("JIRA_API_TOKEN", false);
+
+            const mention = await resolveSlackMention(githubUser, slackToken, ghToken, jiraEmail, jiraToken);
+            fs.appendFileSync(process.env.GITHUB_OUTPUT, "mention=" + mention + "\n");
+          }
+
+          main().catch(e => { console.error(e.message || String(e)); process.exit(2); });
+          NODEEOF

--- a/.github/workflows/shared-ai-feedback-resolve-mention.yml
+++ b/.github/workflows/shared-ai-feedback-resolve-mention.yml
@@ -80,6 +80,19 @@ jobs:
             return null;
           }
 
+          async function slackMentionForEmail(email, slackToken, githubUser) {
+            if (!email) return null;
+            try {
+              const url = new URL("https://slack.com/api/users.lookupByEmail");
+              url.searchParams.set("email", email);
+              const data = await fetchJson(url, { headers: { Authorization: "Bearer " + slackToken } });
+              if (data.ok && data.user?.id) return "<@" + data.user.id + ">";
+            } catch (e) {
+              console.warn("Slack lookupByEmail failed for " + githubUser + ": " + e.message);
+            }
+            return null;
+          }
+
           async function resolveSlackMention(githubUser, slackToken, ghToken, jiraEmail, jiraToken) {
             if (!githubUser) return "@";
 
@@ -95,22 +108,17 @@ jobs:
             } catch (e) {
               console.warn("Could not resolve email for " + githubUser + ": " + e.message);
             }
-            if (!email) {
-              try {
-                email = await jiraEmailForName(jiraName, jiraEmail, jiraToken);
-              } catch (e) {
-                console.warn("Jira lookup failed for " + githubUser + ": " + e.message);
+            let mention = await slackMentionForEmail(email, slackToken, githubUser);
+            if (mention) return mention;
+
+            try {
+              const jiraLookupEmail = await jiraEmailForName(jiraName, jiraEmail, jiraToken);
+              if (jiraLookupEmail && jiraLookupEmail !== email) {
+                mention = await slackMentionForEmail(jiraLookupEmail, slackToken, githubUser);
+                if (mention) return mention;
               }
-            }
-            if (email) {
-              try {
-                const url = new URL("https://slack.com/api/users.lookupByEmail");
-                url.searchParams.set("email", email);
-                const data = await fetchJson(url, { headers: { Authorization: "Bearer " + slackToken } });
-                if (data.ok && data.user?.id) return "<@" + data.user.id + ">";
-              } catch (e) {
-                console.warn("Slack lookupByEmail failed for " + githubUser + ": " + e.message);
-              }
+            } catch (e) {
+              console.warn("Jira lookup failed for " + githubUser + ": " + e.message);
             }
             return "@" + githubUser;
           }

--- a/.github/workflows/shared-ai-feedback-resolve-mention.yml
+++ b/.github/workflows/shared-ai-feedback-resolve-mention.yml
@@ -84,15 +84,23 @@ jobs:
             if (!githubUser) return "@";
 
             let email = null;
+            let jiraName = githubUser;
             try {
               const profile = await fetchJson("https://api.github.com/users/" + githubUser, {
                 headers: { Authorization: "Bearer " + ghToken, Accept: "application/vnd.github+json", "X-GitHub-Api-Version": "2022-11-28" },
               });
               const githubEmail = (profile.email || "").trim().toLowerCase();
               email = githubEmail && !isGithubNoreplyEmail(githubEmail) ? githubEmail : null;
-              if (!email) email = await jiraEmailForName(profile.name || githubUser, jiraEmail, jiraToken);
+              jiraName = profile.name || githubUser;
             } catch (e) {
               console.warn("Could not resolve email for " + githubUser + ": " + e.message);
+            }
+            if (!email) {
+              try {
+                email = await jiraEmailForName(jiraName, jiraEmail, jiraToken);
+              } catch (e) {
+                console.warn("Jira lookup failed for " + githubUser + ": " + e.message);
+              }
             }
             if (email) {
               try {

--- a/.github/workflows/shared-ai-feedback-spec-merged.yml
+++ b/.github/workflows/shared-ai-feedback-spec-merged.yml
@@ -69,8 +69,20 @@ on:
         required: false
 
 jobs:
+  resolve-mention:
+    name: Resolve Slack mention
+    uses: ./.github/workflows/shared-ai-feedback-resolve-mention.yml
+    with:
+      github_user: ${{ inputs.merged_by }}
+    secrets:
+      SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+      GH_TOKEN: ${{ github.token }}
+      JIRA_EMAIL: ${{ secrets.JIRA_EMAIL }}
+      JIRA_API_TOKEN: ${{ secrets.JIRA_API_TOKEN }}
+
   notify:
     name: Post spec feedback prompt to Slack
+    needs: resolve-mention
     runs-on: ubuntu-latest
     steps:
       - name: Set up Node.js
@@ -85,12 +97,10 @@ jobs:
           PR_URL: ${{ inputs.pr_url }}
           PR_BRANCH: ${{ inputs.pr_branch }}
           PR_NUMBER: ${{ inputs.pr_number }}
-          MERGED_BY: ${{ inputs.merged_by }}
+          SLACK_MENTION: ${{ needs.resolve-mention.outputs.mention }}
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
           SLACK_AI_FEEDBACK_CHANNEL_ID: ${{ inputs.slack_channel_id }}
           GITHUB_TOKEN: ${{ github.token }}
-          JIRA_EMAIL: ${{ secrets.JIRA_EMAIL }}
-          JIRA_API_TOKEN: ${{ secrets.JIRA_API_TOKEN }}
         run: |
           node << 'NODEEOF'
           const TICKET_RE = /\b(CC[-_ ]?\d+)\b/i;
@@ -111,49 +121,6 @@ jobs:
             const m = (title + " " + branch).match(TICKET_RE);
             if (!m) return null;
             return m[1].toUpperCase().replace(/^(CC)[-_ ]?(\d+)$/, "CC-$2");
-          }
-
-          function normalizeName(value) {
-            return (value || "").toLowerCase().replace(/[^a-z0-9]+/g, " ").trim().replace(/\s+/g, " ");
-          }
-
-          async function jiraEmailForName(name, jiraEmail, jiraToken) {
-            if (!name || !jiraEmail || !jiraToken) return null;
-            const auth = Buffer.from(jiraEmail + ":" + jiraToken).toString("base64");
-            const url = "https://cartoncloud.atlassian.net/rest/api/3/user/search?query=" + encodeURIComponent(name);
-            const users = await fetchJson(url, {
-              headers: { Authorization: "Basic " + auth, Accept: "application/json" },
-            });
-            if (!Array.isArray(users)) return null;
-            const key = normalizeName(name);
-            for (const u of users) {
-              if (normalizeName(u.displayName) === key && u.emailAddress) return u.emailAddress.toLowerCase();
-            }
-            return null;
-          }
-
-          async function resolveSlackMention(githubUser, slackToken, ghToken, jiraEmail, jiraToken) {
-            let email = null;
-            try {
-              const profile = await fetchJson("https://api.github.com/users/" + githubUser, {
-                headers: { Authorization: "Bearer " + ghToken, Accept: "application/vnd.github+json", "X-GitHub-Api-Version": "2022-11-28" },
-              });
-              email = (profile.email || "").trim().toLowerCase() || null;
-              if (!email && profile.name) email = await jiraEmailForName(profile.name, jiraEmail, jiraToken);
-            } catch (e) {
-              console.warn("Could not resolve email for " + githubUser + ": " + e.message);
-            }
-            if (email) {
-              try {
-                const url = new URL("https://slack.com/api/users.lookupByEmail");
-                url.searchParams.set("email", email);
-                const data = await fetchJson(url, { headers: { Authorization: "Bearer " + slackToken } });
-                if (data.ok && data.user?.id) return "<@" + data.user.id + ">";
-              } catch (e) {
-                console.warn("Slack lookupByEmail failed for " + githubUser + ": " + e.message);
-              }
-            }
-            return "@" + githubUser;
           }
 
           async function countReviewRounds(owner, repo, prNumber, token) {
@@ -178,18 +145,15 @@ jobs:
             const prTitle     = getEnv("PR_TITLE", false);
             const prBranch    = getEnv("PR_BRANCH", false);
             const prUrl       = getEnv("PR_URL");
-            const mergedBy    = getEnv("MERGED_BY");
             const prNumber    = getEnv("PR_NUMBER", false);
+            const mention     = getEnv("SLACK_MENTION");
             const slackToken  = getEnv("SLACK_BOT_TOKEN");
             const channelId   = getEnv("SLACK_AI_FEEDBACK_CHANNEL_ID");
             const ghToken     = getEnv("GITHUB_TOKEN");
-            const jiraEmail   = getEnv("JIRA_EMAIL", false);
-            const jiraToken   = getEnv("JIRA_API_TOKEN", false);
 
             const ticketKey = extractTicketKey(prTitle, prBranch);
             if (!ticketKey) { console.log("No CC-XXXX ticket key found — skipping."); return; }
 
-            const mention    = await resolveSlackMention(mergedBy, slackToken, ghToken, jiraEmail, jiraToken);
             const ticketLink = "<" + prUrl + "|" + ticketKey + ">";
 
             let roundsLine = "";

--- a/.github/workflows/shared-ai-feedback-spec-merged.yml
+++ b/.github/workflows/shared-ai-feedback-spec-merged.yml
@@ -18,20 +18,20 @@ name: AI Feedback — Spec Merged
 #         pr_branch:        ${{ github.event.pull_request.head.ref }}
 #         pr_number:        ${{ github.event.pull_request.number }}
 #         merged_by:        ${{ github.event.pull_request.merged_by.login }}
-#         github_slack_map: ${{ vars.GITHUB_SLACK_MAP }}
 #         slack_channel_id: ${{ vars.SLACK_AI_FEEDBACK_CHANNEL_ID }}
 #       secrets:
 #         SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+#         JIRA_EMAIL:      ${{ secrets.JIRA_EMAIL }}
+#         JIRA_API_TOKEN:  ${{ secrets.JIRA_API_TOKEN }}
 #
 # Required secret (set at org level or in api-documentation):
-#   SLACK_BOT_TOKEN    Slack bot token with chat:write scope
+#   SLACK_BOT_TOKEN    Slack bot token with chat:write, users:read, users:read.email
 #
 # Required variable (set at org level or in api-documentation):
 #   SLACK_AI_FEEDBACK_CHANNEL_ID    Channel ID for #ai-reinforcement-tweaks (or test channel)
 #
-# Optional variable (org-level or repo-level):
-#   GITHUB_SLACK_MAP    JSON string {"githubUsername": "USLACKID"} — enables real @mentions.
-#                       See scripts/github-slack-map.json in local-environment for the source of truth.
+# Optional secrets (improve @mention resolution when GitHub email is private):
+#   JIRA_EMAIL, JIRA_API_TOKEN
 
 on:
   workflow_call:
@@ -56,11 +56,6 @@ on:
         description: GitHub username of the person who merged
         type: string
         required: true
-      github_slack_map:
-        description: JSON string mapping GitHub usernames to Slack member IDs
-        type: string
-        required: false
-        default: "{}"
       slack_channel_id:
         description: Slack channel ID to post to (from vars.SLACK_AI_FEEDBACK_CHANNEL_ID)
         type: string
@@ -68,6 +63,10 @@ on:
     secrets:
       SLACK_BOT_TOKEN:
         required: true
+      JIRA_EMAIL:
+        required: false
+      JIRA_API_TOKEN:
+        required: false
 
 jobs:
   notify:
@@ -87,10 +86,11 @@ jobs:
           PR_BRANCH: ${{ inputs.pr_branch }}
           PR_NUMBER: ${{ inputs.pr_number }}
           MERGED_BY: ${{ inputs.merged_by }}
-          GITHUB_SLACK_MAP: ${{ inputs.github_slack_map }}
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
           SLACK_AI_FEEDBACK_CHANNEL_ID: ${{ inputs.slack_channel_id }}
           GITHUB_TOKEN: ${{ github.token }}
+          JIRA_EMAIL: ${{ secrets.JIRA_EMAIL }}
+          JIRA_API_TOKEN: ${{ secrets.JIRA_API_TOKEN }}
         run: |
           node << 'NODEEOF'
           const TICKET_RE = /\b(CC[-_ ]?\d+)\b/i;
@@ -113,8 +113,46 @@ jobs:
             return m[1].toUpperCase().replace(/^(CC)[-_ ]?(\d+)$/, "CC-$2");
           }
 
-          function slackMention(githubUser, mapStr) {
-            try { const map = JSON.parse(mapStr || "{}"); if (map[githubUser]) return "<@" + map[githubUser] + ">"; } catch {}
+          function normalizeName(value) {
+            return (value || "").toLowerCase().replace(/[^a-z0-9]+/g, " ").trim().replace(/\s+/g, " ");
+          }
+
+          async function jiraEmailForName(name, jiraEmail, jiraToken) {
+            if (!name || !jiraEmail || !jiraToken) return null;
+            const auth = Buffer.from(jiraEmail + ":" + jiraToken).toString("base64");
+            const url = "https://cartoncloud.atlassian.net/rest/api/3/user/search?query=" + encodeURIComponent(name);
+            const users = await fetchJson(url, {
+              headers: { Authorization: "Basic " + auth, Accept: "application/json" },
+            });
+            if (!Array.isArray(users)) return null;
+            const key = normalizeName(name);
+            for (const u of users) {
+              if (normalizeName(u.displayName) === key && u.emailAddress) return u.emailAddress.toLowerCase();
+            }
+            return null;
+          }
+
+          async function resolveSlackMention(githubUser, slackToken, ghToken, jiraEmail, jiraToken) {
+            let email = null;
+            try {
+              const profile = await fetchJson("https://api.github.com/users/" + githubUser, {
+                headers: { Authorization: "Bearer " + ghToken, Accept: "application/vnd.github+json", "X-GitHub-Api-Version": "2022-11-28" },
+              });
+              email = (profile.email || "").trim().toLowerCase() || null;
+              if (!email && profile.name) email = await jiraEmailForName(profile.name, jiraEmail, jiraToken);
+            } catch (e) {
+              console.warn("Could not resolve email for " + githubUser + ": " + e.message);
+            }
+            if (email) {
+              try {
+                const url = new URL("https://slack.com/api/users.lookupByEmail");
+                url.searchParams.set("email", email);
+                const data = await fetchJson(url, { headers: { Authorization: "Bearer " + slackToken } });
+                if (data.ok && data.user?.id) return "<@" + data.user.id + ">";
+              } catch (e) {
+                console.warn("Slack lookupByEmail failed for " + githubUser + ": " + e.message);
+              }
+            }
             return "@" + githubUser;
           }
 
@@ -145,12 +183,13 @@ jobs:
             const slackToken  = getEnv("SLACK_BOT_TOKEN");
             const channelId   = getEnv("SLACK_AI_FEEDBACK_CHANNEL_ID");
             const ghToken     = getEnv("GITHUB_TOKEN");
-            const slackMapStr = getEnv("GITHUB_SLACK_MAP", false);
+            const jiraEmail   = getEnv("JIRA_EMAIL", false);
+            const jiraToken   = getEnv("JIRA_API_TOKEN", false);
 
             const ticketKey = extractTicketKey(prTitle, prBranch);
             if (!ticketKey) { console.log("No CC-XXXX ticket key found — skipping."); return; }
 
-            const mention    = slackMention(mergedBy, slackMapStr);
+            const mention    = await resolveSlackMention(mergedBy, slackToken, ghToken, jiraEmail, jiraToken);
             const ticketLink = "<" + prUrl + "|" + ticketKey + ">";
 
             let roundsLine = "";

--- a/.github/workflows/shared-ai-feedback-ticket-merged.yml
+++ b/.github/workflows/shared-ai-feedback-ticket-merged.yml
@@ -18,22 +18,22 @@ name: AI Feedback — Ticket Merged
 #         pr_url:           ${{ github.event.pull_request.html_url }}
 #         pr_branch:        ${{ github.event.pull_request.head.ref }}
 #         merged_by:        ${{ github.event.pull_request.merged_by.login }}
-#         github_slack_map: ${{ vars.GITHUB_SLACK_MAP }}
 #         slack_channel_id: ${{ vars.SLACK_AI_FEEDBACK_CHANNEL_ID }}
 #       secrets:
 #         SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
 #         GH_READ_TOKEN:   ${{ secrets.GH_READ_TOKEN }}
+#         JIRA_EMAIL:      ${{ secrets.JIRA_EMAIL }}
+#         JIRA_API_TOKEN:  ${{ secrets.JIRA_API_TOKEN }}
 #
 # Required secrets (set at org level or in each calling repo):
-#   SLACK_BOT_TOKEN    Slack bot token with chat:write scope
+#   SLACK_BOT_TOKEN    Slack bot token with chat:write, users:read, users:read.email
 #   GH_READ_TOKEN      PAT with repo:read access to cartoncloud/api-documentation
 #
 # Required variable (set at org level or in each calling repo):
 #   SLACK_AI_FEEDBACK_CHANNEL_ID    Channel ID for #ai-reinforcement-tweaks (or test channel)
 #
-# Optional variable (org-level or repo-level):
-#   GITHUB_SLACK_MAP    JSON string {"githubUsername": "USLACKID"} — enables real @mentions.
-#                       See scripts/github-slack-map.json in local-environment for the source of truth.
+# Optional secrets (improve @mention resolution when GitHub email is private):
+#   JIRA_EMAIL, JIRA_API_TOKEN
 
 on:
   workflow_call:
@@ -54,11 +54,6 @@ on:
         description: GitHub username of the person who merged
         type: string
         required: true
-      github_slack_map:
-        description: JSON string mapping GitHub usernames to Slack member IDs
-        type: string
-        required: false
-        default: "{}"
       slack_channel_id:
         description: Slack channel ID to post to (from vars.SLACK_AI_FEEDBACK_CHANNEL_ID)
         type: string
@@ -68,6 +63,10 @@ on:
         required: true
       GH_READ_TOKEN:
         required: true
+      JIRA_EMAIL:
+        required: false
+      JIRA_API_TOKEN:
+        required: false
 
 jobs:
   notify:
@@ -86,10 +85,11 @@ jobs:
           PR_URL: ${{ inputs.pr_url }}
           PR_BRANCH: ${{ inputs.pr_branch }}
           MERGED_BY: ${{ inputs.merged_by }}
-          GITHUB_SLACK_MAP: ${{ inputs.github_slack_map }}
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
           SLACK_AI_FEEDBACK_CHANNEL_ID: ${{ inputs.slack_channel_id }}
           GITHUB_TOKEN: ${{ secrets.GH_READ_TOKEN }}
+          JIRA_EMAIL: ${{ secrets.JIRA_EMAIL }}
+          JIRA_API_TOKEN: ${{ secrets.JIRA_API_TOKEN }}
         run: |
           node << 'NODEEOF'
           const TICKET_RE = /\b(CC[-_ ]?\d+)\b/i;
@@ -112,8 +112,46 @@ jobs:
             return m[1].toUpperCase().replace(/^(CC)[-_ ]?(\d+)$/, "CC-$2");
           }
 
-          function slackMention(githubUser, mapStr) {
-            try { const map = JSON.parse(mapStr || "{}"); if (map[githubUser]) return "<@" + map[githubUser] + ">"; } catch {}
+          function normalizeName(value) {
+            return (value || "").toLowerCase().replace(/[^a-z0-9]+/g, " ").trim().replace(/\s+/g, " ");
+          }
+
+          async function jiraEmailForName(name, jiraEmail, jiraToken) {
+            if (!name || !jiraEmail || !jiraToken) return null;
+            const auth = Buffer.from(jiraEmail + ":" + jiraToken).toString("base64");
+            const url = "https://cartoncloud.atlassian.net/rest/api/3/user/search?query=" + encodeURIComponent(name);
+            const users = await fetchJson(url, {
+              headers: { Authorization: "Basic " + auth, Accept: "application/json" },
+            });
+            if (!Array.isArray(users)) return null;
+            const key = normalizeName(name);
+            for (const u of users) {
+              if (normalizeName(u.displayName) === key && u.emailAddress) return u.emailAddress.toLowerCase();
+            }
+            return null;
+          }
+
+          async function resolveSlackMention(githubUser, slackToken, ghToken, jiraEmail, jiraToken) {
+            let email = null;
+            try {
+              const profile = await fetchJson("https://api.github.com/users/" + githubUser, {
+                headers: { Authorization: "Bearer " + ghToken, Accept: "application/vnd.github+json", "X-GitHub-Api-Version": "2022-11-28" },
+              });
+              email = (profile.email || "").trim().toLowerCase() || null;
+              if (!email && profile.name) email = await jiraEmailForName(profile.name, jiraEmail, jiraToken);
+            } catch (e) {
+              console.warn("Could not resolve email for " + githubUser + ": " + e.message);
+            }
+            if (email) {
+              try {
+                const url = new URL("https://slack.com/api/users.lookupByEmail");
+                url.searchParams.set("email", email);
+                const data = await fetchJson(url, { headers: { Authorization: "Bearer " + slackToken } });
+                if (data.ok && data.user?.id) return "<@" + data.user.id + ">";
+              } catch (e) {
+                console.warn("Slack lookupByEmail failed for " + githubUser + ": " + e.message);
+              }
+            }
             return "@" + githubUser;
           }
 
@@ -144,7 +182,8 @@ jobs:
             const slackToken  = getEnv("SLACK_BOT_TOKEN");
             const channelId   = getEnv("SLACK_AI_FEEDBACK_CHANNEL_ID");
             const ghToken     = getEnv("GITHUB_TOKEN");
-            const slackMapStr = getEnv("GITHUB_SLACK_MAP", false);
+            const jiraEmail   = getEnv("JIRA_EMAIL", false);
+            const jiraToken   = getEnv("JIRA_API_TOKEN", false);
 
             const ticketKey = extractTicketKey(prTitle, prBranch);
             if (!ticketKey) { console.log("No CC-XXXX ticket key found — skipping."); return; }
@@ -152,7 +191,7 @@ jobs:
             const found = await hasSpecPr(ticketKey, ghToken);
             if (!found) { console.log("No merged spec found for " + ticketKey + " in api-documentation — skipping."); return; }
 
-            const mention    = slackMention(mergedBy, slackMapStr);
+            const mention    = await resolveSlackMention(mergedBy, slackToken, ghToken, jiraEmail, jiraToken);
             const ticketLink = "<" + prUrl + "|" + ticketKey + ">";
 
             const text = [

--- a/.github/workflows/shared-ai-feedback-ticket-merged.yml
+++ b/.github/workflows/shared-ai-feedback-ticket-merged.yml
@@ -69,8 +69,20 @@ on:
         required: false
 
 jobs:
+  resolve-mention:
+    name: Resolve Slack mention
+    uses: ./.github/workflows/shared-ai-feedback-resolve-mention.yml
+    with:
+      github_user: ${{ inputs.merged_by }}
+    secrets:
+      SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+      GH_TOKEN: ${{ secrets.GH_READ_TOKEN }}
+      JIRA_EMAIL: ${{ secrets.JIRA_EMAIL }}
+      JIRA_API_TOKEN: ${{ secrets.JIRA_API_TOKEN }}
+
   notify:
     name: Post ticket feedback prompt to Slack
+    needs: resolve-mention
     runs-on: ubuntu-latest
     steps:
       - name: Set up Node.js
@@ -84,12 +96,10 @@ jobs:
           PR_TITLE: ${{ inputs.pr_title }}
           PR_URL: ${{ inputs.pr_url }}
           PR_BRANCH: ${{ inputs.pr_branch }}
-          MERGED_BY: ${{ inputs.merged_by }}
+          SLACK_MENTION: ${{ needs.resolve-mention.outputs.mention }}
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
           SLACK_AI_FEEDBACK_CHANNEL_ID: ${{ inputs.slack_channel_id }}
           GITHUB_TOKEN: ${{ secrets.GH_READ_TOKEN }}
-          JIRA_EMAIL: ${{ secrets.JIRA_EMAIL }}
-          JIRA_API_TOKEN: ${{ secrets.JIRA_API_TOKEN }}
         run: |
           node << 'NODEEOF'
           const TICKET_RE = /\b(CC[-_ ]?\d+)\b/i;
@@ -110,49 +120,6 @@ jobs:
             const m = (title + " " + branch).match(TICKET_RE);
             if (!m) return null;
             return m[1].toUpperCase().replace(/^(CC)[-_ ]?(\d+)$/, "CC-$2");
-          }
-
-          function normalizeName(value) {
-            return (value || "").toLowerCase().replace(/[^a-z0-9]+/g, " ").trim().replace(/\s+/g, " ");
-          }
-
-          async function jiraEmailForName(name, jiraEmail, jiraToken) {
-            if (!name || !jiraEmail || !jiraToken) return null;
-            const auth = Buffer.from(jiraEmail + ":" + jiraToken).toString("base64");
-            const url = "https://cartoncloud.atlassian.net/rest/api/3/user/search?query=" + encodeURIComponent(name);
-            const users = await fetchJson(url, {
-              headers: { Authorization: "Basic " + auth, Accept: "application/json" },
-            });
-            if (!Array.isArray(users)) return null;
-            const key = normalizeName(name);
-            for (const u of users) {
-              if (normalizeName(u.displayName) === key && u.emailAddress) return u.emailAddress.toLowerCase();
-            }
-            return null;
-          }
-
-          async function resolveSlackMention(githubUser, slackToken, ghToken, jiraEmail, jiraToken) {
-            let email = null;
-            try {
-              const profile = await fetchJson("https://api.github.com/users/" + githubUser, {
-                headers: { Authorization: "Bearer " + ghToken, Accept: "application/vnd.github+json", "X-GitHub-Api-Version": "2022-11-28" },
-              });
-              email = (profile.email || "").trim().toLowerCase() || null;
-              if (!email && profile.name) email = await jiraEmailForName(profile.name, jiraEmail, jiraToken);
-            } catch (e) {
-              console.warn("Could not resolve email for " + githubUser + ": " + e.message);
-            }
-            if (email) {
-              try {
-                const url = new URL("https://slack.com/api/users.lookupByEmail");
-                url.searchParams.set("email", email);
-                const data = await fetchJson(url, { headers: { Authorization: "Bearer " + slackToken } });
-                if (data.ok && data.user?.id) return "<@" + data.user.id + ">";
-              } catch (e) {
-                console.warn("Slack lookupByEmail failed for " + githubUser + ": " + e.message);
-              }
-            }
-            return "@" + githubUser;
           }
 
           async function hasSpecPr(ticketKey, token) {
@@ -178,12 +145,10 @@ jobs:
             const prTitle     = getEnv("PR_TITLE", false);
             const prBranch    = getEnv("PR_BRANCH", false);
             const prUrl       = getEnv("PR_URL");
-            const mergedBy    = getEnv("MERGED_BY");
+            const mention     = getEnv("SLACK_MENTION");
             const slackToken  = getEnv("SLACK_BOT_TOKEN");
             const channelId   = getEnv("SLACK_AI_FEEDBACK_CHANNEL_ID");
             const ghToken     = getEnv("GITHUB_TOKEN");
-            const jiraEmail   = getEnv("JIRA_EMAIL", false);
-            const jiraToken   = getEnv("JIRA_API_TOKEN", false);
 
             const ticketKey = extractTicketKey(prTitle, prBranch);
             if (!ticketKey) { console.log("No CC-XXXX ticket key found — skipping."); return; }
@@ -191,7 +156,6 @@ jobs:
             const found = await hasSpecPr(ticketKey, ghToken);
             if (!found) { console.log("No merged spec found for " + ticketKey + " in api-documentation — skipping."); return; }
 
-            const mention    = await resolveSlackMention(mergedBy, slackToken, ghToken, jiraEmail, jiraToken);
             const ticketLink = "<" + prUrl + "|" + ticketKey + ">";
 
             const text = [


### PR DESCRIPTION
## Summary

- Resolves Slack @mentions via GitHub profile email, optional Jira fallback, and Slack \users.lookupByEmail\
- Removes \GITHUB_SLACK_MAP\ input from both AI feedback reusable workflows

## Test plan

- [ ] Merge and tag on v3
- [ ] Merge api-documentation caller update to pass Jira secrets and drop \github_slack_map\
- [ ] Merge a spec PR and confirm real Slack ping in test channel

Made with [Cursor](https://cursor.com)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Workflows now call GitHub, Slack, and optionally Jira with bot/API tokens; misconfiguration or API failures only degrade to plain @mentions, but callers must update secrets and Slack app scopes.
> 
> **Overview**
> Adds a reusable workflow **`shared-ai-feedback-resolve-mention.yml`** that turns the merge author’s GitHub username into a real Slack `<@user>` mention at runtime, with **`@username`** as fallback.
> 
> Resolution order: public GitHub profile email (skipping noreply) → Slack **`users.lookupByEmail`**; if that fails and **Jira** secrets are set, Jira user search by display name → second Slack lookup. Both **`shared-ai-feedback-spec-merged`** and **`shared-ai-feedback-ticket-merged`** call this job first and pass **`SLACK_MENTION`** into the notify step instead of parsing **`GITHUB_SLACK_MAP`**.
> 
> Callers drop the **`github_slack_map`** input; optional **`JIRA_EMAIL`** / **`JIRA_API_TOKEN`** secrets and expanded Slack bot scopes (**`users:read`**, **`users:read.email`**) are documented in the workflow comments.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7461b3908664c103de39eb93e1c17ea48a102897. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->