### PR TITLE
Resolve api-documentation branch via Jira parent ticket lookup

### DIFF
--- a/api-docs-compliance/README.md
+++ b/api-docs-compliance/README.md
@@ -4,16 +4,42 @@ This GitHub Action enforces API documentation compliance by running an OpenAPI s
 
 ## Features
 - Checks OpenAPI spec compliance on pull requests.
+- Resolves the `api-documentation` branch from Jira ticket keys in the PR head branch (e.g. sub-task `story/CC-47092` → `story/CC-40306`).
 - Posts review comments for violations, blocking merge until resolved (when branch protection is enabled).
 - Supports both public and private `api-documentation` repositories.
 - Integrates with Cursor API for bugbot analysis.
 
 ## Inputs
-| Name                | Description                                                                 | Required | Default                |
-|---------------------|-----------------------------------------------------------------------------|----------|------------------------|
-| `PERSONAL_ACCESS_TOKEN` | GitHub token with access to the `api-documentation` repo (if private)         | Yes      |                        |
-| `CURSOR_API_KEY`    | Cursor API key for bugbot analysis                                            | Yes      |                        |
-| `API_DOCUMENTATION_REPO` | (Optional) Override for the api-documentation repo (e.g. org/repo)           | No       | cartoncloud/api-documentation |
+| Name | Description | Required | Default |
+|------|-------------|----------|---------|
+| `PERSONAL_ACCESS_TOKEN` | GitHub token with access to the `api-documentation` repo (if private) | Yes | |
+| `CURSOR_API_KEY` | Cursor API key for bugbot analysis | Yes | |
+| `API_DOCUMENTATION_REPO` | Override for the api-documentation repo (e.g. org/repo) | No | `cartoncloud/api-documentation` |
+| `HEAD_REF` | PR head branch (e.g. `story/CC-47092`) for Jira ticket and branch resolution | No | |
+| `API_DOCUMENTATION_BRANCH` | Manual override branch; when set, skips automatic branch resolution | No | (empty) |
+| `JIRA_SERVER` | Jira server hostname (e.g. `cartoncloud.atlassian.net`) | No | |
+| `JIRA_USERNAME` | Jira username for parent ticket lookup | No | |
+| `JIRA_PASSWORD` | Jira password or API token for parent ticket lookup | No | |
+
+## Branch resolution
+
+Set `API_DOCUMENTATION_BRANCH` to skip automatic resolution and clone that branch directly (falls back to `main` if the branch does not exist).
+
+Otherwise:
+
+- No `HEAD_REF` → `main`
+- `HEAD_REF` with no `CC-{number}` in the branch name → `main`
+- `HEAD_REF` with a ticket key → list remote branches in `api-documentation` and try ticket keys in order:
+  1. `{head-ticket}` extracted from the PR branch (prefix and suffix on the PR are ignored; e.g. `bug/CC-1234-extra` → `CC-1234`)
+  2. `{jira-parent}` when Jira credentials are set and the head ticket has a parent
+
+For each ticket key, a branch matches if it equals the key (e.g. `CC-40306`) or ends with `/{key}` (e.g. `story/CC-40306`, `bug/CC-40306`). Matches are ranked:
+
+1. bare ticket key (e.g. `CC-40306`)
+2. `{pr-prefix}/{ticket}` when the PR branch has a prefix (e.g. PR `story/CC-47092` prefers `story/CC-40306` over `bug/CC-40306`)
+3. any other matching branch, alphabetically
+
+If no ticket key matches, or the resolved branch cannot be cloned, the action falls back to `main`.
 
 ## Usage
 ```yaml
@@ -27,12 +53,15 @@ on:
 
 jobs:
   api-docs-compliance:
-    uses: ./api-docs-compliance  # or org/repo/path@ref if published
-    secrets:
+    uses: cartoncloud/actions/api-docs-compliance@v3
+    with:
       PERSONAL_ACCESS_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
       CURSOR_API_KEY: ${{ secrets.CURSOR_API_KEY }}
-    with:
-      API_DOCUMENTATION_REPO: cartoncloud/api-documentation  # optional
+      API_DOCUMENTATION_REPO: cartoncloud/api-documentation
+      HEAD_REF: ${{ github.head_ref }}
+      JIRA_SERVER: ${{ vars.JIRA_SERVER }}
+      JIRA_USERNAME: ${{ secrets.JIRA_USERNAME }}
+      JIRA_PASSWORD: ${{ secrets.JIRA_PASSWORD }}
 ```
 
 ## Branch Protection
@@ -42,4 +71,3 @@ To block merges until all bugbot comments are resolved:
 
 ## License
 MIT
-

--- a/api-docs-compliance/action.yml
+++ b/api-docs-compliance/action.yml
@@ -12,9 +12,25 @@ inputs:
     required: false
     default: cartoncloud/api-documentation
   API_DOCUMENTATION_BRANCH:
-    description: 'Branch to use for the api-documentation repo (default: main)'
+    description: 'Optional override branch for api-documentation (skips Jira parent resolution when set)'
     required: false
-    default: main
+    default: ''
+  HEAD_REF:
+    description: 'PR head branch (e.g. story/CC-47092) used to resolve Jira ticket and api-documentation branches'
+    required: false
+    default: ''
+  JIRA_SERVER:
+    description: 'Jira server hostname (e.g. cartoncloud.atlassian.net) for parent ticket lookup'
+    required: false
+    default: ''
+  JIRA_USERNAME:
+    description: 'Jira username for parent ticket lookup'
+    required: false
+    default: ''
+  JIRA_PASSWORD:
+    description: 'Jira password or API token for parent ticket lookup'
+    required: false
+    default: ''
 runs:
   using: composite
   steps:
@@ -23,29 +39,17 @@ runs:
       with:
         fetch-depth: 0
 
-    - name: Checkout api-documentation (with branch fallback)
+    - name: Checkout api-documentation (Jira parent chain + branch fallback)
       shell: bash
       env:
         API_DOCUMENTATION_REPO: ${{ inputs.API_DOCUMENTATION_REPO }}
         API_DOCUMENTATION_BRANCH: ${{ inputs.API_DOCUMENTATION_BRANCH }}
+        HEAD_REF: ${{ inputs.HEAD_REF }}
+        JIRA_SERVER: ${{ inputs.JIRA_SERVER }}
+        JIRA_USERNAME: ${{ inputs.JIRA_USERNAME }}
+        JIRA_PASSWORD: ${{ inputs.JIRA_PASSWORD }}
         PERSONAL_ACCESS_TOKEN: ${{ inputs.PERSONAL_ACCESS_TOKEN }}
-      run: |
-        set -e
-        REPO="$API_DOCUMENTATION_REPO"
-        BRANCH="$API_DOCUMENTATION_BRANCH"
-        TOKEN="$PERSONAL_ACCESS_TOKEN"
-        TARGET_DIR="api-documentation"
-        rm -rf "$TARGET_DIR"
-        if [ "$BRANCH" = "main" ]; then
-          git clone --depth 1 --branch "$BRANCH" "https://x-access-token:$TOKEN@github.com/$REPO.git" "$TARGET_DIR"
-        else
-          if git clone --depth 1 --branch "$BRANCH" "https://x-access-token:$TOKEN@github.com/$REPO.git" "$TARGET_DIR"; then
-            echo "Checked out branch $BRANCH."
-          else
-            echo "Branch $BRANCH not found, falling back to main."
-            git clone --depth 1 --branch main "https://x-access-token:$TOKEN@github.com/$REPO.git" "$TARGET_DIR"
-          fi
-        fi
+      run: bash "${{ github.action_path }}/checkout-api-documentation.sh"
 
     - name: Clear previous API spec bugbot comments
       uses: aki77/delete-pr-comments-action@v3

--- a/api-docs-compliance/checkout-api-documentation.sh
+++ b/api-docs-compliance/checkout-api-documentation.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+TARGET_DIR="api-documentation"
+REPO_URL="https://x-access-token:${PERSONAL_ACCESS_TOKEN}@github.com/${API_DOCUMENTATION_REPO}.git"
+rm -rf "$TARGET_DIR"
+
+find_branch_for_ticket() {
+  local ticket="$1"
+  local remote_heads="$2"
+  local head_prefix="${3:-}"
+  local matches
+  local prefixed
+
+  [ -z "$ticket" ] && return 1
+  matches=$(echo "$remote_heads" | grep -E "^${ticket}$|/${ticket}$" || true)
+  [ -z "$matches" ] && return 1
+
+  if echo "$matches" | grep -qx "$ticket"; then
+    echo "$ticket"
+    return 0
+  fi
+
+  if [ -n "$head_prefix" ]; then
+    prefixed="${head_prefix}/${ticket}"
+    if echo "$matches" | grep -qx "$prefixed"; then
+      echo "$prefixed"
+      return 0
+    fi
+  fi
+
+  echo "$matches" | sort | head -1
+}
+
+if [ -n "${API_DOCUMENTATION_BRANCH:-}" ]; then
+  BRANCH="$API_DOCUMENTATION_BRANCH"
+elif [ -n "${HEAD_REF:-}" ]; then
+  TICKET=$(echo "$HEAD_REF" | grep -oE 'CC-[0-9]+' | head -1 || true)
+  HEAD_PREFIX=""
+  if [[ "$HEAD_REF" =~ ^([^/]+)/ ]]; then
+    HEAD_PREFIX="${BASH_REMATCH[1]}"
+  fi
+  PARENT=""
+  if [ -n "$TICKET" ] && [ -n "${JIRA_SERVER:-}" ] && [ -n "${JIRA_USERNAME:-}" ] && [ -n "${JIRA_PASSWORD:-}" ]; then
+    PARENT=$(curl -sf -u "${JIRA_USERNAME}:${JIRA_PASSWORD}" \
+      "https://${JIRA_SERVER}/rest/api/3/issue/${TICKET}?fields=parent" \
+      | jq -r '.fields.parent.key // empty' || true)
+  fi
+  REMOTE_HEADS=$(git ls-remote --heads "$REPO_URL" 2>/dev/null | awk '{print $2}' | sed 's|refs/heads/||' || true)
+  BRANCH=""
+  for key in "$TICKET" "$PARENT"; do
+    BRANCH=$(find_branch_for_ticket "$key" "$REMOTE_HEADS" "$HEAD_PREFIX" || true)
+    [ -n "$BRANCH" ] && break
+  done
+  [ -z "$BRANCH" ] && BRANCH="main"
+else
+  BRANCH="main"
+fi
+
+if git clone --depth 1 --branch "$BRANCH" "$REPO_URL" "$TARGET_DIR" 2>/dev/null; then
+  echo "Checked out ${TARGET_DIR} branch ${BRANCH}."
+else
+  echo "Branch ${BRANCH} not found, falling back to main."
+  git clone --depth 1 --branch main "$REPO_URL" "$TARGET_DIR"
+fi


### PR DESCRIPTION
## Summary
- Resolve the `api-documentation` checkout branch from Jira ticket keys in the PR head branch instead of always defaulting to `main`
- Look up the Jira parent ticket when credentials are provided (e.g. sub-task `CC-47092` → `story/CC-40306`)
- Match api-documentation branches by ticket key regardless of prefix (`story/CC-40306`, `bug/CC-40306`, `CC-40306`)
- Keep backward compatibility: repos without Jira creds or `HEAD_REF` still fall back to `main`

## Test plan
- [ ] Push branch and pin `webapp-php` workflow to `@tech/parent-ticket-lookup-api-doc-compliance` on PR #7729
- [ ] Confirm checkout log shows `story/CC-40306` (not `main`) for `story/CC-47092`
- [ ] Confirm API Documentation Compliance no longer reports false-positive undocumented packing-slip endpoints
- [ ] Merge to `v3` and re-run with `@v3` on consumer repos


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which OpenAPI spec runs in CI (can affect compliance results) and optionally uses Jira credentials in the workflow; behavior still falls back to `main` when resolution fails or inputs are omitted.
> 
> **Overview**
> The **API Documentation Compliance** action no longer always clones `api-documentation` at `main`. Checkout logic moves into `checkout-api-documentation.sh`, which picks a branch from the PR head ref, optional Jira parent lookup, and remote branch name matching (with `main` as fallback).
> 
> **`API_DOCUMENTATION_BRANCH`** is now an optional override (default empty) that skips automatic resolution when set. New inputs **`HEAD_REF`**, **`JIRA_SERVER`**, **`JIRA_USERNAME`**, and **`JIRA_PASSWORD`** drive ticket extraction (`CC-{number}`), parent issue lookup, and ranked branch selection (bare key, then `{pr-prefix}/{ticket}`, then other matches). The README documents this behavior and updates the consumer workflow example to pass `HEAD_REF` and Jira settings via `cartoncloud/actions/api-docs-compliance@v3`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 38450b340878366d37c30ad33f116d33f584aa46. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->