### PR TITLE
Skip PR risk review on release/* branches

### DIFF
--- a/.github/workflows/pr-risk-review.yml
+++ b/.github/workflows/pr-risk-review.yml
@@ -40,6 +40,7 @@ jobs:
     if: >
       github.event.pull_request.draft == false
       && github.actor != 'dependabot[bot]'
+      && !startsWith(github.event.pull_request.head.ref, 'release/')
     runs-on: ubuntu-latest
     timeout-minutes: 20
     permissions:


### PR DESCRIPTION
### Why?

Release branches should not run the automated PR risk classifier.

### How?

Adds a job-level condition so the reusable `pr-risk-review` workflow skips when the PR head branch starts with `release/`.

<sub>Generated with Cursor</sub>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only guard on when the reusable risk-review job runs; no application or auth/data logic changes.
> 
> **Overview**
> The reusable **PR Risk Review** workflow no longer runs when the pull request’s **head branch** name starts with `release/`.
> 
> The `risk-review` job `if` condition now includes `!startsWith(github.event.pull_request.head.ref, 'release/')`, alongside the existing skips for draft PRs and Dependabot. Release-branch PRs will not get Cursor-based risk classification, labels, sticky comments, or automated low-risk approval from this job.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1df857e4920d9784f4afa7f2851dd70a9e2a3576. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->