### PR TITLE
CC-99900 test: skip (invalid branch format)

### DIFF
--- a/branch-commit-ticket-match/test-scenarios/02-skip-invalid-branch.md
+++ b/branch-commit-ticket-match/test-scenarios/02-skip-invalid-branch.md
@@ -1,0 +1,5 @@
+# Test scenario: 02-skip-invalid-branch
+
+**Branch:** `tech/CC-99901-invalid-suffix`
+
+**Expected:** Skip — branch is not type/CC-XXXXX; no comment posted or deleted


### PR DESCRIPTION
## Test scenario: 02-skip-invalid-branch

**Branch:** `tech/CC-99901-invalid-suffix`

**Expected outcome:** Skip — branch is not type/CC-XXXXX; no comment posted or deleted

Automated test PR for [`branch-commit-ticket-match`](./branch-commit-ticket-match/action.yml). Check the **Test Branch Commit Ticket Match** workflow run and PR comments.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only changes with no application runtime impact; uses standard PR comment APIs and optional skip for non-matching branch names.
> 
> **Overview**
> Introduces a **branch commit ticket match** GitHub Action and wiring so PRs can enforce that commit subjects starting with `CC-####` align with the ticket in a `type/CC-####` branch name.
> 
> The composite action lists PR commits via the GitHub API, skips branches that do not match `^[a-z]+/CC-####$` (e.g. extra suffix), and on mismatch posts or updates a sticky PR comment; it clears that comment when checks pass or when the branch format causes a skip. A **reusable workflow** exposes this for other repos at `@v3`, and a **path-filtered test workflow** runs the local `./branch-commit-ticket-match` action on changes under that folder. This diff also adds test scenario **02-skip-invalid-branch** documenting expected skip behavior for non-conforming branch names.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ac8706e78bb7ba332b164b51e87bc85db4b11961. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->