### PR TITLE
CC-99900 - Add branch commit ticket match action

### DIFF
--- a/.github/workflows/branch-commit-ticket-match.yml
+++ b/.github/workflows/branch-commit-ticket-match.yml
@@ -1,0 +1,41 @@
+# Reusable workflow: verifies commit messages that start with a ticket key match
+# the CC number in the branch name (e.g. hotfix/CC-47680).
+#
+# Call from any repository, e.g.:
+#
+#   name: Branch Commit Ticket Match
+#   on:
+#     pull_request:
+#       types: [opened, synchronize, reopened, edited]
+#   jobs:
+#     branch-commit-ticket-match:
+#       permissions:
+#         pull-requests: write
+#       uses: cartoncloud/actions/.github/workflows/branch-commit-ticket-match.yml@v3
+#       secrets:
+#         PERSONAL_ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+name: Branch Commit Ticket Match
+
+on:
+  workflow_call:
+    secrets:
+      PERSONAL_ACCESS_TOKEN:
+        required: false
+
+concurrency:
+  group: branch-commit-ticket-match-${{ github.repository }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  branch-commit-ticket-match:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Check commit tickets against branch
+        uses: cartoncloud/actions/branch-commit-ticket-match@v3
+        with:
+          PERSONAL_ACCESS_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN || github.token }}

--- a/.github/workflows/test-branch-commit-ticket-match.yml
+++ b/.github/workflows/test-branch-commit-ticket-match.yml
@@ -1,0 +1,27 @@
+# Runs branch-commit-ticket-match locally on PRs that touch test scenario files.
+# Used to validate the action before publishing @v3 consumers can call.
+name: Test Branch Commit Ticket Match
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, edited]
+    paths:
+      - 'branch-commit-ticket-match/**'
+      - '.github/workflows/test-branch-commit-ticket-match.yml'
+
+concurrency:
+  group: test-branch-commit-ticket-match-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  branch-commit-ticket-match:
+    if: github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Check commit tickets against branch
+        uses: ./branch-commit-ticket-match
+        with:
+          PERSONAL_ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test-branch-commit-ticket-match.yml
+++ b/.github/workflows/test-branch-commit-ticket-match.yml
@@ -21,6 +21,8 @@ jobs:
     permissions:
       pull-requests: write
     steps:
+      - uses: actions/checkout@v6
+
       - name: Check commit tickets against branch
         uses: ./branch-commit-ticket-match
         with:

--- a/branch-commit-ticket-match/action.yml
+++ b/branch-commit-ticket-match/action.yml
@@ -1,0 +1,106 @@
+name: 'Branch Commit Ticket Match'
+description: 'Checks that commit messages starting with a ticket key match the CC number in the branch name (type/CC-XXXXX).'
+inputs:
+  PERSONAL_ACCESS_TOKEN:
+    description: 'GitHub token with pull-requests:write on the target repo'
+    required: true
+runs:
+  using: composite
+  steps:
+    - name: Check commit tickets against branch
+      id: check
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.PERSONAL_ACCESS_TOKEN }}
+        PR_NUM: ${{ github.event.pull_request.number }}
+        BRANCH: ${{ github.head_ref || github.event.pull_request.head.ref }}
+        REPO: ${{ github.repository }}
+      run: |
+        set -euo pipefail
+
+        if [ -z "${PR_NUM:-}" ]; then
+          echo "::error::This action must run in a pull_request workflow." >&2
+          exit 1
+        fi
+
+        branch_ticket=
+        if [[ "$BRANCH" =~ ^[a-z]+/([Cc][Cc]-[0-9]+)$ ]]; then
+          branch_ticket=$(echo "${BASH_REMATCH[1]}" | tr '[:lower:]' '[:upper:]')
+        else
+          echo "Branch '$BRANCH' does not match type/CC-XXXXX; skipping."
+          echo "should_check=0" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+
+        echo "Checking commits on branch $BRANCH (expected ticket prefix: $branch_ticket)"
+
+        mismatches=()
+        while IFS= read -r line; do
+          [ -z "$line" ] && continue
+          sha="${line%% *}"
+          subject="${line#* }"
+          short_sha="${sha:0:7}"
+
+          if [[ ! "$subject" =~ ^[Cc][Cc]-[0-9]+ ]]; then
+            continue
+          fi
+
+          commit_ticket=$(echo "$subject" | sed -E 's/^([Cc][Cc]-[0-9]+).*/\1/' | tr '[:lower:]' '[:upper:]')
+          if [ "$commit_ticket" != "$branch_ticket" ]; then
+            mismatches+=("$short_sha|$commit_ticket|$subject")
+          fi
+        done < <(
+          gh api "repos/$REPO/pulls/$PR_NUM/commits" --paginate \
+            | jq -r '.[] | "\(.sha) \(.commit.message | split("\n")[0])"'
+        )
+
+        echo "should_check=1" >> "$GITHUB_OUTPUT"
+
+        if [ "${#mismatches[@]}" -eq 0 ]; then
+          echo "All ticket-prefixed commits match $branch_ticket."
+          echo "has_mismatches=0" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+
+        echo "Found ${#mismatches[@]} commit(s) with a mismatched ticket prefix."
+        echo "has_mismatches=1" >> "$GITHUB_OUTPUT"
+
+        {
+          echo "### Commit message / branch ticket mismatch"
+          echo ""
+          echo "Branch \`$BRANCH\` expects commit messages that start with a ticket key to use **$branch_ticket**."
+          echo ""
+          echo "| Commit | Ticket in message | Message |"
+          echo "| --- | --- | --- |"
+          for entry in "${mismatches[@]}"; do
+            IFS='|' read -r short_sha commit_ticket subject <<< "$entry"
+            subject="${subject//|/\\|}"
+            echo "| [\`$short_sha\`](https://github.com/$REPO/pull/$PR_NUM/commits/$short_sha) | \`$commit_ticket\` | $subject |"
+          done
+          echo ""
+          echo "Commits without a ticket prefix at the start are ignored. Update the commit message or branch name so they align."
+        } > /tmp/branch-commit-ticket-match-comment.md
+
+    - name: Remove previous comment
+      if: steps.check.outputs.should_check == '1' && steps.check.outputs.has_mismatches == '1'
+      uses: marocchino/sticky-pull-request-comment@v2
+      with:
+        header: branch-commit-ticket-match
+        delete: true
+        GITHUB_TOKEN: ${{ inputs.PERSONAL_ACCESS_TOKEN }}
+
+    - name: Post mismatch comment
+      if: steps.check.outputs.should_check == '1' && steps.check.outputs.has_mismatches == '1'
+      uses: marocchino/sticky-pull-request-comment@v2
+      with:
+        header: branch-commit-ticket-match
+        path: /tmp/branch-commit-ticket-match-comment.md
+        GITHUB_TOKEN: ${{ inputs.PERSONAL_ACCESS_TOKEN }}
+
+    - name: Remove comment when checks pass
+      if: steps.check.outputs.should_check == '1' && steps.check.outputs.has_mismatches != '1'
+      uses: marocchino/sticky-pull-request-comment@v2
+      with:
+        header: branch-commit-ticket-match
+        delete: true
+        GITHUB_TOKEN: ${{ inputs.PERSONAL_ACCESS_TOKEN }}


### PR DESCRIPTION
## Summary
- Adds `branch-commit-ticket-match` composite action
- Adds reusable workflow for consumer repos
- Adds local `test-branch-commit-ticket-match` workflow for validation

## Test plan
See companion test PRs #588–#595 (each documents expected outcome in `branch-commit-ticket-match/test-scenarios/`).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only automation that comments on PRs; no application runtime or data-path changes, though it needs pull-requests write and API access to list commits.
> 
> **Overview**
> Adds a **branch commit ticket match** check so PRs on branches like `type/CC-XXXXX` get feedback when a commit message *starts* with a different `CC-` ticket than the branch.
> 
> The new composite action `branch-commit-ticket-match` loads PR commits via the GitHub API, compares ticket prefixes, and uses a sticky PR comment (same pattern as `pr-risk-review`) to post a mismatch table or clear the comment when aligned. Branches that do not match `type/CC-XXXXX` are skipped without failing.
> 
> A **reusable workflow** (`.github/workflows/branch-commit-ticket-match.yml`) exposes this for other repos at `cartoncloud/actions/...@v3`, with optional `PERSONAL_ACCESS_TOKEN` and PR concurrency. A **path-filtered test workflow** runs the local `./branch-commit-ticket-match` action on changes under that directory before consumers pin `@v3`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7d1ab3500a7043e4006eee557afcfb7299578389. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->