### PR TITLE
CC-99900 test: fail then pass (comment cleanup on fix)

### DIFF
--- a/branch-commit-ticket-match/test-scenarios/09-fail-then-pass.md
+++ b/branch-commit-ticket-match/test-scenarios/09-fail-then-pass.md
@@ -1,0 +1,5 @@
+# Test scenario: 09-fail-then-pass
+
+**Branch:** `hotfix/CC-99910`
+
+**Expected:** Fail initially, then pass after fix push — comment deleted on re-run


### PR DESCRIPTION
## Test scenario: 09-fail-then-pass

**Expected:** Sticky comment posted on first run, then deleted after the commit is corrected.

This PR will be force-pushed with a matching ticket after the first workflow run completes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only addition for a manual/automated test scenario; no production code or workflow logic changes in this diff.
> 
> **Overview**
> Adds **`test-scenarios/09-fail-then-pass.md`**, documenting scenario **09-fail-then-pass** for the branch/commit ticket match checks.
> 
> The file specifies branch **`hotfix/CC-99910`** and the expected behavior: the check **fails on the first run**, **passes after a corrective push**, and any **sticky PR comment is removed on re-run**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit da010267fe35e1d535aaaf319a46c1cd0fb5abc3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->