### PR TITLE
Replace Cursor CLI with webhook-based PR risk review

### DIFF
--- a/.github/workflows/pr-risk-review-cursor-automation.yml
+++ b/.github/workflows/pr-risk-review-cursor-automation.yml
@@ -1,0 +1,431 @@
+# PR risk classifier via Cursor Automation webhook (reusable workflow).
+#
+# Drop-in successor to pr-risk-review.yml (Cursor CLI). Migrate callers during a grace period:
+# keep pr-risk-review.yml@ v3 until ready, then switch the `uses:` line below.
+#
+# Call from application repos, for example:
+#
+#   name: PR Risk Review
+#   on:
+#     pull_request:
+#       types: [opened, synchronize, reopened, ready_for_review]
+#   jobs:
+#     risk-review:
+#       permissions:
+#         contents: read
+#         pull-requests: write
+#       uses: cartoncloud/actions/.github/workflows/pr-risk-review-cursor-automation.yml@v3
+#       secrets: inherit
+#
+# Prerequisites (organisation, set once):
+# - Organisation secret: PR_RISK_REVIEW_WEBHOOK_TOKEN (Cursor automation webhook bearer token; no Bearer prefix)
+# - Caller workflows must use `secrets: inherit` so the reusable workflow can read that org secret
+# - Cursor automation prompt: see pr-risk-review-cursor-automation/AUTOMATION_PROMPT.md (Comment on PRs only; marker-only review)
+#
+# Webhook URL is defined in this workflow (shared Cursor automation for all repos).
+#
+# Flow: POST webhook → cursor[bot] posts marker-only PR review → GHA parses marker →
+# delete prior human-facing issue comments → post fresh issue comment → hide bot reviews → labels / auto-approve.
+
+name: PR Risk Review (Cursor Automation)
+
+on:
+  workflow_call:
+
+env:
+  PR_RISK_REVIEW_WEBHOOK_URL: https://api2.cursor.sh/automations/webhook/2d07b79d-29c5-4920-bfad-dc4fedc0d7b2
+
+concurrency:
+  group: risk-review-${{ github.repository }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  risk-review:
+    if: >
+      github.event.pull_request.draft == false
+      && github.actor != 'dependabot[bot]'
+      && !startsWith(github.event.pull_request.head.ref, 'release/')
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Require Cursor automation webhook token
+        env:
+          PR_RISK_REVIEW_WEBHOOK_TOKEN: ${{ secrets.PR_RISK_REVIEW_WEBHOOK_TOKEN }}
+        run: |
+          if [ -z "$PR_RISK_REVIEW_WEBHOOK_TOKEN" ]; then
+            echo 'Set organisation secret PR_RISK_REVIEW_WEBHOOK_TOKEN and call this workflow with secrets: inherit.' >&2
+            exit 1
+          fi
+
+      - name: Export PR diff artifacts
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR: ${{ github.event.pull_request.number }}
+        run: |
+          gh pr diff "$PR" --repo "$REPO" > pr-diff.patch
+          gh pr diff "$PR" --repo "$REPO" --name-only > changed-files.txt
+
+      - name: Truncate very large diffs
+        run: |
+          limit=400000
+          size=$(wc -c < pr-diff.patch | tr -d ' ')
+          if [ "$size" -gt "$limit" ]; then
+            head -c "$limit" pr-diff.patch > pr-diff.truncated.patch
+            mv pr-diff.truncated.patch pr-diff.patch
+            {
+              echo ""
+              echo "[diff truncated at ${limit} bytes for agent context; missing lines may hide risk — classifier should not assume low risk solely from visible content]"
+            } >> pr-diff.patch
+          fi
+
+      - name: Build webhook payload
+        env:
+          REPOSITORY: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+          IS_FORK: ${{ github.event.pull_request.head.repo.full_name != github.repository }}
+        run: |
+          set -euo pipefail
+          python3 <<'PY'
+          import json, os, pathlib
+          diff = pathlib.Path("pr-diff.patch").read_text(encoding="utf-8", errors="replace")
+          files = [line.strip() for line in pathlib.Path("changed-files.txt").read_text(encoding="utf-8").splitlines() if line.strip()]
+          payload = {
+            "workflow": "pr-risk-review-cursor-automation",
+            "repository": os.environ["REPOSITORY"],
+            "pr_number": int(os.environ["PR_NUMBER"]),
+            "pr_url": os.environ["PR_URL"],
+            "head_ref": os.environ["HEAD_REF"],
+            "head_sha": os.environ["HEAD_SHA"],
+            "base_ref": os.environ["BASE_REF"],
+            "is_fork": os.environ["IS_FORK"].lower() == "true",
+            "changed_files": files,
+            "diff": diff,
+          }
+          pathlib.Path("webhook-payload.json").write_text(json.dumps(payload), encoding="utf-8")
+          PY
+
+      - name: Trigger Cursor risk review automation
+        run: |
+          set -euo pipefail
+          http_code="$(curl -sS -o /tmp/webhook-response.txt -w "%{http_code}" -X POST "$PR_RISK_REVIEW_WEBHOOK_URL" \
+            -H "Authorization: Bearer ${{ secrets.PR_RISK_REVIEW_WEBHOOK_TOKEN }}" \
+            -H "Content-Type: application/json" \
+            --data-binary @webhook-payload.json)"
+          if [ "$http_code" -lt 200 ] || [ "$http_code" -ge 300 ]; then
+            echo "Webhook returned HTTP ${http_code}:" >&2
+            cat /tmp/webhook-response.txt >&2 || true
+            exit 1
+          fi
+          cat /tmp/webhook-response.txt
+
+      - name: Wait for automation review and parse risk
+        id: parse
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR: ${{ github.event.pull_request.number }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PYTHONUTF8: "1"
+        run: |
+          set -euo pipefail
+          python3 <<'PY'
+          import json, os, re, subprocess, sys, time
+
+          repo, pr = os.environ["REPO"], os.environ["PR"]
+          head_sha = os.environ["HEAD_SHA"]
+          deadline = time.time() + 2 * 60
+          pattern = re.compile(r"<!-- pr-risk-review:(.*?) -->", re.DOTALL)
+          trigger_after = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+
+          def fetch_reviews():
+              out = subprocess.check_output(
+                  ["gh", "api", f"repos/{repo}/pulls/{pr}/reviews", "--paginate"],
+                  text=True,
+              )
+              return json.loads(out)
+
+          while time.time() < deadline:
+              for review in reversed(fetch_reviews()):
+                  user = (review.get("user") or {}).get("login", "")
+                  if user not in ("cursor[bot]", "cursor"):
+                      continue
+                  body = review.get("body") or ""
+                  match = pattern.search(body)
+                  if not match:
+                      continue
+                  submitted = review.get("submitted_at") or ""
+                  if submitted < trigger_after:
+                      continue
+                  data = json.loads(match.group(1))
+                  if data.get("head_sha") not in (None, head_sha):
+                      continue
+                  risk = str(data.get("risk_level", "")).strip().lower()
+                  if risk not in {"low", "medium", "high"}:
+                      print(f"Invalid risk_level: {risk!r}", file=sys.stderr)
+                      sys.exit(1)
+                  with open("risk.json", "w", encoding="utf-8") as f:
+                      json.dump(data, f, ensure_ascii=False, indent=2)
+                  with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as gh:
+                      gh.write(f"risk_level={risk}\n")
+                      gh.write(f"marker_review_id={review.get('id', '')}\n")
+                      gh.write(f"marker_review_node_id={review.get('node_id', '')}\n")
+                  print(f"Parsed risk review submitted_at={submitted} risk_level={risk}")
+                  sys.exit(0)
+              time.sleep(10)
+
+          print("Timed out after 2 minutes waiting for cursor[bot] pr-risk-review marker", file=sys.stderr)
+          sys.exit(1)
+          PY
+
+      - name: Ensure risk labels exist
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          repo="${{ github.repository }}"
+          gh label create "risk: low" --color "2ECC71" --description "PR risk — low" --repo "$repo" 2>/dev/null || true
+          gh label create "risk: medium" --color "F1C40F" --description "PR risk — medium" --repo "$repo" 2>/dev/null || true
+          gh label create "risk: high" --color "E74C3C" --description "PR risk — high" --repo "$repo" 2>/dev/null || true
+
+      - name: Apply risk labels
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          RISK=$(jq -r '.risk_level' risk.json)
+          DESIRED="risk: ${RISK}"
+
+          action=$(gh pr view "$PR" --repo "$REPO" --json labels | jq -r --arg desired "$DESIRED" '
+            [.labels[].name
+              | select(. == "risk: low" or . == "risk: medium" or . == "risk: high")]
+            | unique
+            | if length == 1 and .[0] == $desired then "skip" else "apply" end
+          ')
+
+          if [ "$action" = "skip" ]; then
+            echo "Risk label already ${DESIRED}; leaving labels unchanged."
+            exit 0
+          fi
+
+          for L in "risk: low" "risk: medium" "risk: high"; do
+            gh pr edit "$PR" --repo "$REPO" --remove-label "$L" 2>/dev/null || true
+          done
+          gh pr edit "$PR" --repo "$REPO" --add-label "$DESIRED"
+
+      - name: Clear previous risk review comments
+        uses: aki77/delete-pr-comments-action@v3
+        with:
+          token: ${{ github.token }}
+          pullRequestNumber: ${{ github.event.pull_request.number }}
+          includeIssueComments: 'true'
+          includeOverallReviewComments: 'true'
+          bodyContains: |-
+            Automated risk review
+          usernames: |-
+            github-actions[bot]
+
+      - name: Post risk review comment
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          python3 <<'PY'
+          import json
+
+          with open("risk.json", encoding="utf-8") as f:
+              data = json.load(f)
+
+          risk = data.get("risk_level", "")
+          rationale = str(data.get("rationale", "")).strip()
+          signals = data.get("signals") or []
+
+          lines = [
+              "### Automated risk review",
+              "",
+              f"**Level:** `risk: {risk}`",
+              "",
+              f"**Rationale:** {rationale}",
+              "",
+              "**Signals**",
+          ]
+          if signals:
+              for item in signals:
+                  lines.append(f"- {item}")
+          else:
+              lines.append("_None listed_")
+
+          lines.extend(
+              [
+                  "",
+                  "_This is advisory automation; humans remain responsible for merge decisions._",
+              ]
+          )
+
+          with open("risk-comment.md", "w", encoding="utf-8") as out:
+              out.write("\n".join(lines))
+              out.write("\n")
+          PY
+          jq -n --rawfile body risk-comment.md '{body: $body}' > /tmp/risk-comment.json
+          gh api "repos/$REPO/issues/$PR/comments" --method POST --input /tmp/risk-comment.json
+
+      - name: Remove bot marker reviews and legacy review posts
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR: ${{ github.event.pull_request.number }}
+        run: |
+          set +euo pipefail
+          python3 <<'PY'
+          import json, os, re, subprocess, sys
+
+          repo, pr = os.environ["REPO"], os.environ["PR"]
+          marker = re.compile(r"<!-- pr-risk-review:")
+          cursor_users = {"cursor[bot]", "cursor"}
+
+          def gh_json(args):
+              out = subprocess.check_output(["gh", "api", *args], text=True)
+              return json.loads(out)
+
+          def minimize_review(node_id: str, label: str) -> bool:
+              proc = subprocess.run(
+                  [
+                      "gh", "api", "graphql", "-f",
+                      f"query=mutation($subjectId: ID!) {{ minimizeComment(input: {{subjectId: $subjectId, classifier: OUTDATED}}) {{ minimizedComment {{ isMinimized }} }} }}",
+                      f"subjectId={node_id}",
+                  ],
+                  capture_output=True,
+                  text=True,
+              )
+              if proc.returncode == 0:
+                  print(f"Minimized {label} {node_id}")
+                  return True
+              print(proc.stderr.strip() or proc.stdout.strip(), file=sys.stderr)
+              return False
+
+          reviews = gh_json([f"repos/{repo}/pulls/{pr}/reviews", "--paginate"])
+          for review in reviews:
+              user = (review.get("user") or {}).get("login", "")
+              body = review.get("body") or ""
+              is_cursor_marker = user in cursor_users and marker.search(body)
+              is_legacy_actions_review = user == "github-actions[bot]" and "Automated risk review" in body
+              if not is_cursor_marker and not is_legacy_actions_review:
+                  continue
+              review_id = review.get("id")
+              node_id = review.get("node_id") or ""
+              if is_cursor_marker and review_id:
+                  proc = subprocess.run(
+                      ["gh", "api", "--method", "DELETE", f"repos/{repo}/pulls/{pr}/reviews/{review_id}"],
+                      capture_output=True,
+                      text=True,
+                  )
+                  if proc.returncode == 0:
+                      print(f"Deleted pending cursor review {review_id}")
+                      continue
+              if node_id and minimize_review(node_id, "review"):
+                  continue
+              print(f"::warning::Could not remove review {review_id} from {user}", file=sys.stderr)
+
+          comments = gh_json([f"repos/{repo}/issues/{pr}/comments", "--paginate"])
+          for comment in comments:
+              user = (comment.get("user") or {}).get("login", "")
+              if user not in cursor_users:
+                  continue
+              body = comment.get("body") or ""
+              if not marker.search(body):
+                  continue
+              comment_id = comment.get("id")
+              if not comment_id:
+                  continue
+              proc = subprocess.run(
+                  ["gh", "api", "--method", "DELETE", f"repos/{repo}/issues/comments/{comment_id}"],
+                  capture_output=True,
+                  text=True,
+              )
+              if proc.returncode == 0:
+                  print(f"Deleted cursor issue comment {comment_id}")
+              else:
+                  print(f"::warning::Could not delete cursor issue comment {comment_id}", file=sys.stderr)
+          PY
+
+      - name: Revoke automated approval when risk is not low
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -uo pipefail
+          if [ "${{ github.event.pull_request.head.repo.full_name }}" != "${{ github.repository }}" ]; then
+            echo "Skipping approval revocation on fork PRs."
+            exit 0
+          fi
+          RISK="${{ steps.parse.outputs.risk_level }}"
+          PR="${{ github.event.pull_request.number }}"
+          REPO="${{ github.repository }}"
+
+          if [ "$RISK" = "low" ]; then
+            exit 0
+          fi
+
+          count_bot_approved() {
+            gh api --paginate "repos/${REPO}/pulls/${PR}/reviews" --jq '[.[] | select(.state == "APPROVED" and .user.login == "github-actions[bot]")] | length'
+          }
+
+          BEFORE=$(count_bot_approved)
+          if [ "${BEFORE:-0}" -eq 0 ]; then
+            echo "No automated approvals to revoke."
+            exit 0
+          fi
+
+          while read -r rid; do
+            [ -z "${rid:-}" ] && continue
+            if gh api \
+              --method PUT \
+              "repos/${REPO}/pulls/${PR}/reviews/${rid}/dismissals" \
+              -f message="Risk level reassessed as ${RISK} (not low); dismissing automated low-risk approval." \
+              -f event=DISMISS 2>/dev/null; then
+              echo "Dismissed review ${rid}"
+            else
+              echo "::warning title=Dismiss review failed::Could not PUT dismissals for review ${rid}; will try supersede via request-changes if needed."
+            fi
+          done < <(gh api --paginate "repos/${REPO}/pulls/${PR}/reviews" --jq '[.[] | select(.state == "APPROVED" and .user.login == "github-actions[bot]") | .id] | sort | reverse | .[]')
+
+          AFTER=$(count_bot_approved)
+          if [ "${AFTER:-0}" -eq 0 ]; then
+            echo "Automated approvals cleared."
+            exit 0
+          fi
+
+          echo "Superseding remaining bot approval via request-changes (dismiss unavailable or insufficient permission)."
+          body_file="$(mktemp)"
+          printf '%s\n\n%s\n' "Automated reassessment marked this PR as **${RISK}** risk (not low). An earlier approve from github-actions bot is superseded by this review." "(Used when dismissal of the automated approval fails for your repo or rules.)" > "${body_file}"
+          gh pr review "${PR}" --repo "${REPO}" --request-changes --body-file "${body_file}" || true
+          rm -f "${body_file}"
+
+      - name: Auto-approve low-risk PRs
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          if [ "${{ github.event.pull_request.head.repo.full_name }}" != "${{ github.repository }}" ]; then
+            echo "Skipping auto-approve for fork PRs."
+            exit 0
+          fi
+          RISK="${{ steps.parse.outputs.risk_level }}"
+          if [ "$RISK" != "low" ]; then
+            exit 0
+          fi
+          if gh pr view "$PR" --repo "$REPO" --json reviewDecision --jq '.reviewDecision == "APPROVED"' | grep -q true; then
+            exit 0
+          fi
+          gh pr review "$PR" --repo "$REPO" --approve --body "Automated low-risk classification. One human reviewer may still be required by branch protection."

--- a/.github/workflows/pr-risk-review.yml
+++ b/.github/workflows/pr-risk-review.yml
@@ -18,6 +18,8 @@
 # Prerequisites on the caller repository:
 # - Actions secret: CURSOR_API_KEY (https://cursor.com/docs/cli/reference/authentication)
 #
+# Successor (webhook, no per-repo API key): pr-risk-review-cursor-automation.yml
+#
 # Classifier model: Cursor Composer 2.5 (`composer-2.5`).
 #
 # Branch protection: GitHub cannot set "1 reviewer for low / 2 for high" per PR in native rules.

--- a/pr-risk-review-cursor-automation/AUTOMATION_PROMPT.md
+++ b/pr-risk-review-cursor-automation/AUTOMATION_PROMPT.md
@@ -1,0 +1,77 @@
+# PR Risk Review (Cursor Automation) — prompt
+
+Use this prompt in the Cursor Automation wired to the shared webhook. Enable **Comment on PRs** only. Do **not** enable Manage check runs (the cloud agent has no `gh` / `GH_TOKEN` access).
+
+GitHub Actions posts the human-facing issue comment. This automation only returns machine-readable output via a PR review from `cursor[bot]`.
+
+---
+
+You classify pull-request risk for CartonCloud production applications.
+
+## Input
+
+This run was triggered by a webhook. The request body is the only source of truth for PR context. Do not assume the checked-out workspace matches the PR.
+
+Read these fields from the webhook payload:
+
+- `repository` — e.g. `cartoncloud/service-user`
+- `pr_number` — pull request number
+- `pr_url` — link to the PR (for your reference)
+- `head_ref`, `head_sha`, `base_ref` — branch context
+- `is_fork` — boolean; fork PRs are advisory only
+- `changed_files` — array of file paths (one per entry)
+- `diff` — unified diff; may end with a truncation note
+
+If `changed_files` or `diff` is missing or empty, post a PR review on `repository` + `pr_number` whose body is only:
+
+`<!-- pr-risk-review:{"head_sha":"{head_sha}","risk_level":"medium","rationale":"Insufficient diff or changed_files in webhook payload.","signals":["Missing or empty classification input"]} -->`
+
+Then stop.
+
+## Task
+
+Assign exactly one risk level for the change set as a whole: `low`, `medium`, or `high`.
+
+### Guidelines
+
+**low**
+- User-visible copy only: UI labels, help text, translations, comments, static docs
+- History/audit log messages that do not affect permissions, billing, or security behaviour
+- Purely cosmetic presentation with no logic or data changes
+- Analytics instrumentation only
+- Permission changes are **low** only when adding **new** permissions (new capability keys, new role-action pairs, new feature flags scoped to authorization) **without** changing how any **existing** permission is interpreted, enforced, or assigned
+
+**high**
+- Billing, payments, invoicing, subscriptions, pricing, refunds, credits
+- Authentication, authorization, sessions, passwords, tokens, OAuth, roles/permissions
+- Modifying **existing** permissions (semantics, enforcement, conditions, mappings, defaults, or what existing roles/users can do — even if the diff looks small)
+- Secrets or production credentials
+- Changes to how PII or money moves
+- Security-sensitive crypto
+- External integrations or webhooks that affect charging, identity, or regulated data
+- Migrations or config that alter financial or auth enforcement
+
+**medium**
+- All other code or behaviour changes: bug fixes, refactors, APIs, data paths, non-financial integrations, performance, tests, build, etc.
+
+### Rules
+
+- If torn between two levels, choose the **higher** one.
+- Truncated diffs may omit material context; do **not** output `low` if uncertainty remains.
+- Classify from `changed_files` and `diff` together; file paths alone can justify a higher level (e.g. `*Permission*`, `*Auth*`, `*Billing*`, migrations).
+
+## Output
+
+Use **Comment on PRs** on `repository` + `pr_number`.
+
+Post a PR review whose **body contains only** this single line (escape `"` inside strings as `\"`):
+
+`<!-- pr-risk-review:{"head_sha":"{head_sha from payload}","risk_level":"{risk_level}","rationale":"{rationale}","signals":["…"]} -->`
+
+Do not include markdown, rationale prose, signals lists, headings, or Cursor footer text in the review body. GitHub Actions reads this marker, posts the human-facing issue comment, then hides this marker review.
+
+## Do not
+
+- Do not use Manage check runs or `gh` CLI
+- Do not post a human-readable review comment (no ### headings, no bullet lists)
+- Do not approve, request changes, or add labels


### PR DESCRIPTION
## Why?
The PR risk review reusable workflow currently runs the Cursor CLI in CI with per-repo CURSOR_API_KEY secrets. This is slow, brittle (checkout/diff/gh issues), and couples each repo to CLI auth. We need a shared webhook-driven automation that classifies risk via cursor[bot] markers while GHA handles labels, human-facing comments, and auto-approve policy.

## How?
Replace CLI execution with a Cursor automation webhook (org secret + hardcoded URL). GHA exports PR diff without checkout, polls for marker-only cursor[bot] reviews, posts deletable issue comments (delete-and-repost), cleans up bot markers, and applies existing label/approval logic.

## Test plan
- [ ] Trigger PR risk review on a test PR and confirm webhook receives diff payload
- [ ] Verify cursor[bot] marker review appears and is cleaned up after processing
- [ ] Confirm issue comments are delete-and-reposted correctly
- [ ] Validate label and auto-approve behavior matches prior workflow

<sub>Generated with Cursor</sub>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes org-wide PR merge automation (labels, comments, auto-approve/revoke) and depends on external webhook timing; misclassification or timeout could affect review policy.
> 
> **Overview**
> Adds a **drop-in reusable workflow** that replaces in-CI **Cursor CLI** classification with a shared **Cursor Automation webhook**. Callers use org secret `PR_RISK_REVIEW_WEBHOOK_TOKEN` and `secrets: inherit` instead of per-repo `CURSOR_API_KEY`.
> 
> **GHA** still exports the PR diff via `gh` (no checkout), truncates large patches, POSTs JSON to the automation, then **polls** for a `cursor[bot]` PR review containing the `<!-- pr-risk-review:… -->` marker. It parses risk JSON, applies `risk: *` labels, and keeps the existing **auto-approve / revoke** behavior for same-repo PRs.
> 
> **Human-facing output** moves from sticky comments to **delete-and-repost** issue comments (`aki77/delete-pr-comments-action`), plus steps to **delete/minimize** marker reviews and legacy bot review noise. Timeout drops from 20 to **5 minutes**.
> 
> Documents the automation prompt in `pr-risk-review-cursor-automation/AUTOMATION_PROMPT.md`. The legacy `pr-risk-review.yml` workflow is unchanged except a comment pointing at the successor for migration.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dffa8ad79f9c1e609d6cf4d251b599f621f539ba. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->