### PR TITLE
PLT-2258 - Skip stale auto-deploys when revision changed

### DIFF
--- a/.github/workflows/shared-branch-push-java.yml
+++ b/.github/workflows/shared-branch-push-java.yml
@@ -129,7 +129,22 @@ jobs:
       url: ${{ matrix.environment.url }}
 
     steps:
+      - name: Verify environment still tracks this revision
+        id: verify-revision
+        uses: cartoncloud/actions/jira-environment-revision-still-tracked@v3
+        with:
+          jiraServer: ${{ vars.JIRA_SERVER }}
+          jiraUsername: ${{ secrets.JIRA_USERNAME }}
+          jiraPassword: ${{ secrets.JIRA_PASSWORD }}
+          projectKey: ${{ vars.JIRA_ENVIRONMENT_PROJECT_KEY }}
+          appName: ${{ inputs.appName }}
+          revision: ${{ github.ref_name }}
+          environmentName: ${{ matrix.environment.name }}
+          nameField: ${{ vars.JIRA_ENVIRONMENT_KEY_FIELD }}
+          urlField: ${{ vars.JIRA_ENVIRONMENT_URL_FIELD }}
+
       - name: Deploy
+        if: steps.verify-revision.outputs.still-tracked == 'true'
         uses: cartoncloud/actions/deploy-java@v3
         with:
           appName: ${{ inputs.appName }}

--- a/jira-environment-revision-still-tracked/action.yml
+++ b/jira-environment-revision-still-tracked/action.yml
@@ -1,0 +1,64 @@
+name: 'Jira Environment Revision Still Tracked'
+description: 'Checks whether a Jira environment still tracks the given git revision before deploying'
+inputs:
+  jiraServer:
+    description: 'Jira server address i.e. acme.atlassian.net'
+    required: true
+  jiraUsername:
+    description: 'Jira username to use to call the API'
+    required: true
+  jiraPassword:
+    description: 'Jira password to use to call the API'
+    required: true
+  projectKey:
+    description: 'Jira project key i.e. ENV'
+    required: true
+  appName:
+    description: 'App/project name i.e. php'
+    required: true
+  revision:
+    description: 'Git branch or tag the deploy expects the environment to track'
+    required: true
+  environmentName:
+    description: 'GitHub environment name to verify'
+    required: true
+  nameField:
+    description: 'JSON field for the environment name'
+    required: true
+  urlField:
+    description: 'JSON field for the environment URL'
+    required: true
+
+outputs:
+  still-tracked:
+    description: 'Whether the environment still tracks the given revision'
+    value: ${{ steps.check.outputs.still-tracked }}
+
+runs:
+  using: composite
+  steps:
+    - uses: ./jira-environment-revision-search
+      id: search
+      with:
+        jiraServer: ${{ inputs.jiraServer }}
+        jiraUsername: ${{ inputs.jiraUsername }}
+        jiraPassword: ${{ inputs.jiraPassword }}
+        projectKey: ${{ inputs.projectKey }}
+        appName: ${{ inputs.appName }}
+        revision: ${{ inputs.revision }}
+        nameField: ${{ inputs.nameField }}
+        urlField: ${{ inputs.urlField }}
+
+    - id: check
+      shell: bash
+      env:
+        ENVIRONMENTS: ${{ steps.search.outputs.environments }}
+        ENVIRONMENT_NAME: ${{ inputs.environmentName }}
+        REVISION: ${{ inputs.revision }}
+      run: |
+        if echo "$ENVIRONMENTS" | jq -e --arg name "$ENVIRONMENT_NAME" '.[] | select(.name == $name)' > /dev/null; then
+          echo "still-tracked=true" >> "$GITHUB_OUTPUT"
+        else
+          echo "Environment $ENVIRONMENT_NAME no longer tracks $REVISION, skipping stale deploy"
+          echo "still-tracked=false" >> "$GITHUB_OUTPUT"
+        fi

--- a/jira-environment-revision-still-tracked/action.yml
+++ b/jira-environment-revision-still-tracked/action.yml
@@ -56,6 +56,11 @@ runs:
         ENVIRONMENT_NAME: ${{ inputs.environmentName }}
         REVISION: ${{ inputs.revision }}
       run: |
+        if [ -z "$ENVIRONMENTS" ] || ! echo "$ENVIRONMENTS" | jq -e 'type == "array"' > /dev/null; then
+          echo "Jira environment search failed or did not return environments"
+          exit 1
+        fi
+
         if echo "$ENVIRONMENTS" | jq -e --arg name "$ENVIRONMENT_NAME" '.[] | select(.name == $name)' > /dev/null; then
           echo "still-tracked=true" >> "$GITHUB_OUTPUT"
         else


### PR DESCRIPTION
## Summary
- Adds `jira-environment-revision-still-tracked` composite action to re-check Jira environment revision immediately before deploy
- Uses it in `shared-branch-push-java.yml` so Java services skip stale automatic deploys when an environment was retargeted (e.g. by a manual deploy) after the workflow started

## Jira
https://cartoncloud.atlassian.net/browse/PLT-2258

## Test plan
- [x] Merge this PR first
- [x] Verify dependent webapp-php and webapp-js PRs pass CI once this is on `v3`


Made with [Cursor](https://cursor.com)