### PR TITLE
PLT-2258 - Fix composite action sub-action path

### DIFF
--- a/jira-environment-revision-still-tracked/action.yml
+++ b/jira-environment-revision-still-tracked/action.yml
@@ -37,7 +37,7 @@ outputs:
 runs:
   using: composite
   steps:
-    - uses: ./jira-environment-revision-search
+    - uses: cartoncloud/actions/jira-environment-revision-search@v3
       id: search
       with:
         jiraServer: ${{ inputs.jiraServer }}


### PR DESCRIPTION
## Summary
- Fix `jira-environment-revision-still-tracked` composite action failing in consumer repos (webapp-js/webapp-php Deploy jobs)
- Root cause: `./jira-environment-revision-search` relative path only works when the actions repo is checked out; consumer workflows run verify before checkout
- Change sub-action reference to `cartoncloud/actions/jira-environment-revision-search@v3` (matches other composite actions in this repo)

## Test plan
- [ ] Merge and tag/point `@v3` at updated commit
- [ ] Re-run webapp-js/webapp-php `bug/PLT-2258` Deploy smoke test workflows


Made with [Cursor](https://cursor.com)