### PR TITLE
Skip API docs compliance when no API-relevant files changed

### DIFF
--- a/api-docs-compliance-cursor-automation/action.yml
+++ b/api-docs-compliance-cursor-automation/action.yml
@@ -38,7 +38,113 @@ runs:
           exit 1
         fi
 
+    - name: Decide whether to run
+      id: scope
+      shell: bash
+      env:
+        GH_TOKEN: ${{ github.token }}
+        REPO: ${{ github.repository }}
+        PR: ${{ github.event.pull_request.number }}
+        EVENT_NAME: ${{ github.event_name }}
+        BEFORE: ${{ github.event.before }}
+        AFTER: ${{ github.event.after }}
+      run: |
+        set -euo pipefail
+        python3 <<'PY'
+        import fnmatch, json, os, subprocess
+
+        PATTERNS = [
+            "openapi/**",
+            "**/controller/**",
+            "**/Api*Controller.php",
+            "config/routes.php",
+            "**/*-definition-schema.json",
+        ]
+        ZERO_SHA = "0" * 40
+
+        def path_matches(path: str, pattern: str) -> bool:
+            path = path.replace("\\", "/").lstrip("./")
+            pattern = pattern.replace("\\", "/")
+            if "**" not in pattern:
+                return fnmatch.fnmatchcase(path, pattern)
+            if pattern.startswith("**/") and pattern.endswith("/**"):
+                middle = pattern[3:-3]
+                if middle:
+                    return f"/{middle}/" in f"/{path}/" or path == middle or path.startswith(middle + "/")
+                return True
+            if "/**/" in pattern:
+                left, right = pattern.split("/**/", 1)
+                if path == left:
+                    return fnmatch.fnmatchcase("", right) if right else True
+                if not (path == left or path.startswith(left + "/")):
+                    return False
+                rest = path[len(left):].lstrip("/")
+                parts = rest.split("/")
+                for i in range(len(parts)):
+                    if fnmatch.fnmatchcase("/".join(parts[i:]), right):
+                        return True
+                return False
+            if pattern.endswith("/**"):
+                prefix = pattern[:-3]
+                return path == prefix or path.startswith(prefix + "/")
+            if pattern.startswith("**/"):
+                suffix = pattern[3:]
+                if fnmatch.fnmatchcase(path, suffix):
+                    return True
+                parts = path.split("/")
+                for i in range(len(parts)):
+                    if fnmatch.fnmatchcase("/".join(parts[i:]), suffix):
+                        return True
+                return False
+            return fnmatch.fnmatchcase(path, pattern)
+
+        def matched_files(paths):
+            matched = []
+            for path in paths:
+                path = path.strip()
+                if not path:
+                    continue
+                for pattern in PATTERNS:
+                    if path_matches(path, pattern):
+                        matched.append(path)
+                        break
+            return matched
+
+        repo = os.environ["REPO"]
+        pr = os.environ["PR"]
+        event = os.environ["EVENT_NAME"]
+        before = os.environ.get("BEFORE", "")
+        use_full_pr_diff = event in ("opened", "reopened", "workflow_dispatch") or (event == "synchronize" and before in ("", ZERO_SHA))
+
+        if use_full_pr_diff:
+            out = subprocess.check_output(["gh", "pr", "diff", pr, "--repo", repo, "--name-only"], text=True)
+            files = [line.strip() for line in out.splitlines() if line.strip()]
+        elif event == "synchronize":
+            after = os.environ["AFTER"]
+            out = subprocess.check_output(["gh", "api", f"repos/{repo}/compare/{before}...{after}", "--jq", ".files[].filename"], text=True)
+            files = [line.strip() for line in out.splitlines() if line.strip()]
+        else:
+            print(f"Unknown event {event!r}; using full PR diff for scope.")
+            out = subprocess.check_output(["gh", "pr", "diff", pr, "--repo", repo, "--name-only"], text=True)
+            files = [line.strip() for line in out.splitlines() if line.strip()]
+
+        matched = matched_files(files)
+        should_run = bool(matched)
+        print(f"Event: {event}")
+        print(f"Files considered: {len(files)}")
+        print(f"matched_files={json.dumps(matched)}")
+        if should_run:
+            print("API-relevant changes detected; running compliance check.")
+        else:
+            print("No API-relevant changes; skipping compliance check.")
+
+        with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as gh:
+            gh.write(f"should_run={'true' if should_run else 'false'}\n")
+            gh.write(f"matched_files={json.dumps(matched)}\n")
+        PY
+
     - name: Export PR diff artifacts
+      if: steps.scope.outputs.should_run == 'true'
       shell: bash
       env:
         GH_TOKEN: ${{ github.token }}
@@ -50,6 +156,7 @@ runs:
         gh pr diff "$PR" --repo "$REPO" --name-only > changed-files.txt
 
     - name: Truncate very large diffs
+      if: steps.scope.outputs.should_run == 'true'
       shell: bash
       run: |
         set -euo pipefail
@@ -65,6 +172,7 @@ runs:
         fi
 
     - name: Build webhook payload
+      if: steps.scope.outputs.should_run == 'true'
       shell: bash
       env:
         REPOSITORY: ${{ github.repository }}
@@ -98,6 +206,7 @@ runs:
         PY
 
     - name: Trigger Cursor API docs compliance automation
+      if: steps.scope.outputs.should_run == 'true'
       shell: bash
       env:
         API_DOCS_COMPLIANCE_WEBHOOK_URL: ${{ inputs.API_DOCS_COMPLIANCE_WEBHOOK_URL }}
@@ -116,6 +225,7 @@ runs:
         cat /tmp/webhook-response.txt
 
     - name: Wait for automation review and parse compliance
+      if: steps.scope.outputs.should_run == 'true'
       id: parse
       shell: bash
       env:
@@ -176,6 +286,7 @@ runs:
         PY
 
     - name: Clear previous API spec compliance comments
+      if: steps.scope.outputs.should_run == 'true'
       uses: aki77/delete-pr-comments-action@v3
       with:
         token: ${{ github.token }}
@@ -190,6 +301,7 @@ runs:
           github-actions[bot]
 
     - name: Create pull request review when violations found
+      if: steps.scope.outputs.should_run == 'true'
       shell: bash
       env:
         GH_TOKEN: ${{ github.token }}
@@ -222,7 +334,7 @@ runs:
         echo "Pull request review posted (body-only; avoids GitHub 422 on unresolved line)."
 
     - name: Remove bot marker reviews and comments
-      if: always()
+      if: always() && steps.scope.outputs.should_run == 'true'
       shell: bash
       env:
         GH_TOKEN: ${{ github.token }}

--- a/api-docs-compliance/action.yml
+++ b/api-docs-compliance/action.yml
@@ -18,12 +18,119 @@ inputs:
 runs:
   using: composite
   steps:
+    - name: Decide whether to run
+      id: scope
+      shell: bash
+      env:
+        GH_TOKEN: ${{ github.token }}
+        REPO: ${{ github.repository }}
+        PR: ${{ github.event.pull_request.number }}
+        EVENT_NAME: ${{ github.event_name }}
+        BEFORE: ${{ github.event.before }}
+        AFTER: ${{ github.event.after }}
+      run: |
+        set -euo pipefail
+        python3 <<'PY'
+        import fnmatch, json, os, subprocess
+
+        PATTERNS = [
+            "openapi/**",
+            "**/controller/**",
+            "**/Api*Controller.php",
+            "config/routes.php",
+            "**/*-definition-schema.json",
+        ]
+        ZERO_SHA = "0" * 40
+
+        def path_matches(path: str, pattern: str) -> bool:
+            path = path.replace("\\", "/").lstrip("./")
+            pattern = pattern.replace("\\", "/")
+            if "**" not in pattern:
+                return fnmatch.fnmatchcase(path, pattern)
+            if pattern.startswith("**/") and pattern.endswith("/**"):
+                middle = pattern[3:-3]
+                if middle:
+                    return f"/{middle}/" in f"/{path}/" or path == middle or path.startswith(middle + "/")
+                return True
+            if "/**/" in pattern:
+                left, right = pattern.split("/**/", 1)
+                if path == left:
+                    return fnmatch.fnmatchcase("", right) if right else True
+                if not (path == left or path.startswith(left + "/")):
+                    return False
+                rest = path[len(left):].lstrip("/")
+                parts = rest.split("/")
+                for i in range(len(parts)):
+                    if fnmatch.fnmatchcase("/".join(parts[i:]), right):
+                        return True
+                return False
+            if pattern.endswith("/**"):
+                prefix = pattern[:-3]
+                return path == prefix or path.startswith(prefix + "/")
+            if pattern.startswith("**/"):
+                suffix = pattern[3:]
+                if fnmatch.fnmatchcase(path, suffix):
+                    return True
+                parts = path.split("/")
+                for i in range(len(parts)):
+                    if fnmatch.fnmatchcase("/".join(parts[i:]), suffix):
+                        return True
+                return False
+            return fnmatch.fnmatchcase(path, pattern)
+
+        def matched_files(paths):
+            matched = []
+            for path in paths:
+                path = path.strip()
+                if not path:
+                    continue
+                for pattern in PATTERNS:
+                    if path_matches(path, pattern):
+                        matched.append(path)
+                        break
+            return matched
+
+        repo = os.environ["REPO"]
+        pr = os.environ["PR"]
+        event = os.environ["EVENT_NAME"]
+        before = os.environ.get("BEFORE", "")
+        use_full_pr_diff = event in ("opened", "reopened", "workflow_dispatch") or (event == "synchronize" and before in ("", ZERO_SHA))
+
+        if use_full_pr_diff:
+            out = subprocess.check_output(["gh", "pr", "diff", pr, "--repo", repo, "--name-only"], text=True)
+            files = [line.strip() for line in out.splitlines() if line.strip()]
+        elif event == "synchronize":
+            after = os.environ["AFTER"]
+            out = subprocess.check_output(["gh", "api", f"repos/{repo}/compare/{before}...{after}", "--jq", ".files[].filename"], text=True)
+            files = [line.strip() for line in out.splitlines() if line.strip()]
+        else:
+            print(f"Unknown event {event!r}; using full PR diff for scope.")
+            out = subprocess.check_output(["gh", "pr", "diff", pr, "--repo", repo, "--name-only"], text=True)
+            files = [line.strip() for line in out.splitlines() if line.strip()]
+
+        matched = matched_files(files)
+        should_run = bool(matched)
+        print(f"Event: {event}")
+        print(f"Files considered: {len(files)}")
+        print(f"matched_files={json.dumps(matched)}")
+        if should_run:
+            print("API-relevant changes detected; running compliance check.")
+        else:
+            print("No API-relevant changes; skipping compliance check.")
+
+        with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as gh:
+            gh.write(f"should_run={'true' if should_run else 'false'}\n")
+            gh.write(f"matched_files={json.dumps(matched)}\n")
+        PY
+
     - name: Checkout target repository
+      if: steps.scope.outputs.should_run == 'true'
       uses: actions/checkout@v6
       with:
         fetch-depth: 0
 
     - name: Checkout api-documentation (with branch fallback)
+      if: steps.scope.outputs.should_run == 'true'
       shell: bash
       env:
         API_DOCUMENTATION_REPO: ${{ inputs.API_DOCUMENTATION_REPO }}
@@ -48,6 +155,7 @@ runs:
         fi
 
     - name: Clear previous API spec bugbot comments
+      if: steps.scope.outputs.should_run == 'true'
       uses: aki77/delete-pr-comments-action@v3
       with:
         token: ${{ inputs.PERSONAL_ACCESS_TOKEN }}
@@ -62,6 +170,7 @@ runs:
           github-actions[bot]
 
     - name: Prepare API spec contract review skill and OpenAPI spec
+      if: steps.scope.outputs.should_run == 'true'
       shell: bash
       run: |
         set -euo pipefail
@@ -89,6 +198,7 @@ runs:
         done
 
     - name: Install Cursor CLI
+      if: steps.scope.outputs.should_run == 'true'
       shell: bash
       run: |
         curl https://cursor.com/install -fsSL | bash
@@ -96,6 +206,7 @@ runs:
         echo "CURSOR_BIN=$HOME/.cursor/bin" >> $GITHUB_ENV
 
     - name: Run OpenAPI spec contract review (Cursor CLI)
+      if: steps.scope.outputs.should_run == 'true'
       id: bugbot
       shell: bash
       env:
@@ -129,6 +240,7 @@ runs:
     # Body-only review: GitHub returns 422 "Line could not be resolved" for inline comments when
     # `line` is not part of the PR diff (e.g. hardcoded line: 1 on unchanged context).
     - name: Create pull request review when violations found
+      if: steps.scope.outputs.should_run == 'true'
       shell: bash
       env:
         GH_TOKEN: ${{ inputs.PERSONAL_ACCESS_TOKEN }}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Incorrect glob matching or an incomplete pattern list could skip compliance on PRs that still affect the API contract; logic is duplicated across two actions so drift is possible.
> 
> **Overview**
> Both **API Documentation Compliance** composite actions now run a **Decide whether to run** step before checkout, webhooks, or Cursor review. Changed paths are collected from the full PR on open/reopen/dispatch (or unknown events), or from the **synchronize** push range via compare API when `before` is valid; they are matched against API-related globs (`openapi/**`, controllers, `config/routes.php`, definition schemas, etc.). **`should_run`** gates every downstream step; when nothing matches, the workflow exits early with no compliance run.
> 
> The Cursor automation variant keeps webhook URL/token validation always-on, but ties marker cleanup to **`always() && should_run`** so skipped PRs do not run parse/cleanup steps that would fail without outputs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 69fcffed917753471b9e59e622bdd541c28adebf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->